### PR TITLE
Add CLAUDE.md — never push to main, use PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Project rules for Claude
+
+## Git workflow
+
+**Never push directly to `main`.** Even when the remote accepts the push (bypass rights exist on this repo), the branch is protected and the maintainer expects all changes to go through pull requests.
+
+When asked to "commit and push", interpret that as:
+
+1. Create a feature branch (`git checkout -b <short-descriptive-name>`).
+2. Commit the changes there.
+3. Push the branch with `-u` to set upstream.
+4. Open a PR with `gh pr create` and return the PR URL.
+
+If you're already sitting on `main` with local commits when this comes up, move them to a new branch before pushing — do not push `main` directly. Reset `main` to `origin/main` only after the new branch is in place and pushed.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` documenting the git workflow Claude should follow on this repo: branch + commit + push -u + `gh pr create`, never direct push to `main`.
- Captures the rule that even though the remote allows bypass pushes, the maintainer prefers all changes flow through PRs.

## Test plan
- [ ] Confirm the wording reflects the intent (recovery path included for "already on main" case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)