### PR TITLE
Add weekly-sampling tool + Sonnet batch-size guidance

### DIFF
--- a/runs/matrix-sampled/partition.json
+++ b/runs/matrix-sampled/partition.json
@@ -1,0 +1,5581 @@
+{
+  "created_at": "2026-04-28T13:16:31Z",
+  "seed": 42,
+  "cells_per_week": 540,
+  "budget_constraint": {
+    "sonnet_weekly_tokens": 30000000,
+    "budget_fraction": 0.9,
+    "tokens_per_cell": 50000,
+    "derived_cells_per_week": 540
+  },
+  "batch_size": 15,
+  "total_cells": 1110,
+  "total_weeks": 3,
+  "weeks": [
+    {
+      "week": 1,
+      "cells": [
+        {
+          "matrix": "expert",
+          "row_id": "101",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "065",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "005",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "013",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "099",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "071",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "116",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n203",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n079",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n198",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n200",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n059",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n119",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "016",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n126",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "010",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "031",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n177",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "030",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n081",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n012",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "050",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n116",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "132",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "119",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n046",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n019",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "027",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "086",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n157",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "066",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "052",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n004",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n057",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n109",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n115",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n122",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n186",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n102",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n172",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n216",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n017",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n149",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n174",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n113",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n145",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n070",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n208",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "100",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n043",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "053",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "096",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "006",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "143",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "088",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n135",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n165",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n183",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n144",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n187",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n194",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n093",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "012",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n059",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n044",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "133",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n104",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "076",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n007",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n021",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "102",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "123",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n135",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "055",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n045",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "081",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "002",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n060",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n026",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n176",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n089",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "130",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "050",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n138",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "068",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "041",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "074",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "117",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n098",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n124",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n179",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n112",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "028",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n044",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n173",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "008",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n064",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "019",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "122",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "023",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n119",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "008",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n135",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n183",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n029",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n042",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "012",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n061",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n061",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n126",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n215",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n178",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n082",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n025",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "036",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n035",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n152",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n018",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "111",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n061",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n192",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "133",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n132",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n086",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "095",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n117",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "062",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n121",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "110",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n021",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "088",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "139",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "035",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n210",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "040",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n008",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n153",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n027",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n194",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "140",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n089",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n062",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n123",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "023",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "067",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n064",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "147",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "071",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n117",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "017",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n170",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n048",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n204",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "039",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n078",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "025",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n177",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "094",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "094",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n073",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n217",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "063",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "035",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n094",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n120",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n166",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n177",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n060",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "087",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n070",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "129",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n077",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "023",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n058",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "054",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "018",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n162",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n127",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "134",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n107",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "049",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n020",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n011",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "096",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "026",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n108",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "039",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n123",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n120",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "020",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n067",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n151",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "052",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n152",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n084",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "011",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "022",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "115",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "128",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "049",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n195",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n052",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n014",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "059",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "113",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "050",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "007",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n196",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n030",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "006",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "010",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n173",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n073",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "078",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n176",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n160",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n196",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "127",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n015",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n161",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n016",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "148",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n188",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "105",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n175",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "110",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n014",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n143",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n041",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n155",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n163",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "121",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n180",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n104",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n182",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n056",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "100",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n022",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n022",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n049",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "031",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n016",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n094",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "017",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "072",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "138",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n142",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n002",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n098",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n087",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n084",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n067",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n013",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n083",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "140",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n095",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n150",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n218",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "088",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n090",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "033",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n092",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n012",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n190",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "092",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "108",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "136",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n002",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n040",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "073",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "059",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n104",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "126",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "124",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n168",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n089",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n020",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "038",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n158",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n207",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n088",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "077",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "084",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n141",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "125",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n198",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "135",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n010",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n154",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "015",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "033",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "089",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n028",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "095",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n101",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n127",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "112",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "045",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n066",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n215",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n047",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n101",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n144",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n148",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n214",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "135",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "135",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n090",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "080",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n200",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n033",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "134",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "015",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "042",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n115",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n086",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "118",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n149",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n047",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "083",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n090",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n070",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "047",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n054",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "031",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n113",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "127",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n146",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "109",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "062",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "074",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n215",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n193",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n118",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "003",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "059",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n165",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "087",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n041",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n210",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n046",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n116",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "091",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "060",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n147",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "097",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n217",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n105",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "052",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n080",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n036",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n046",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n171",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "013",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "034",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n201",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "065",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n147",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n127",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "122",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n160",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "099",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n132",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n084",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n103",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "126",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "123",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "104",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "029",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "063",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n157",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n060",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n009",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n053",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n133",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n179",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n152",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n066",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "022",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n081",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n011",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "142",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n025",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n151",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n020",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n123",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "007",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n202",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "012",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "111",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n074",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "060",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "009",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n014",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "128",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n075",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n056",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n199",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "044",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n133",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n093",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n206",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n052",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "130",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "145",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "144",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "078",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n171",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "056",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n003",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n077",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n032",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n188",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "079",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n106",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n140",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n156",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n174",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "142",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n055",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n179",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n114",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n158",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n213",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n063",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n212",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n147",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "080",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "029",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n189",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "070",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n169",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n130",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "115",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "058",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n037",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "005",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n018",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "075",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n015",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "148",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n028",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n186",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n041",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n029",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "094",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "126",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n150",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "092",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "072",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "143",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n106",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n096",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "129",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n167",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n139",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n078",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n099",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n112",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "099",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n079",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n001",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n191",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "004",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "119",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "100",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n050",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n005",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n030",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n156",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "143",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n068",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "011",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n133",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "080",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "093",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n155",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n082",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "071",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n142",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n027",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "121",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "027",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "119",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n102",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n207",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n074",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n091",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "014",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "093",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n219",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n063",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "058",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "047",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "041",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n200",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "122",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n053",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n145",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "047",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n105",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "107",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n137",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "089",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "133",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "131",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n189",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n213",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n068",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "043",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "129",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "089",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n004",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n088",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "055",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n003",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "146",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n023",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n125",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "109",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n141",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "046",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n006",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "042",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n170",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n110",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n009",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "061",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n189",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n194",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n085",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "002",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n072",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "084",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n056",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n019",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n206",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "067",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "142",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n205",
+          "role": "B"
+        }
+      ]
+    },
+    {
+      "week": 2,
+      "cells": [
+        {
+          "matrix": "newcomer",
+          "row_id": "n115",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n156",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n091",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "016",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n065",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "051",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n169",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n171",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "106",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n111",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n122",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "115",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n026",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "097",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "029",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "058",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n137",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n051",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n201",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n037",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n076",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n204",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "110",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n071",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n069",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "098",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "104",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n166",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n038",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "139",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "103",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n218",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n119",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "144",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n128",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n131",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n087",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "101",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n130",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n199",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "140",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "106",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n169",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n180",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "043",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n052",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n142",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n057",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n163",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "125",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "068",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n034",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n028",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "001",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n145",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n087",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "087",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n114",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n138",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n183",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n055",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n025",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "149",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n130",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "118",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "149",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n159",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n103",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n092",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n049",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n181",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n159",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n085",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "010",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "114",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n128",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "137",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n188",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "120",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n154",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "024",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n136",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "113",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n151",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "066",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "009",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n220",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "078",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "105",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "120",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n008",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "069",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "076",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n011",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "014",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "131",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "037",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n185",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n178",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n129",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "141",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "114",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "062",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "009",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "141",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "061",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "056",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n122",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n114",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n062",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n185",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n042",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n134",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "036",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n125",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n180",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "123",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n202",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "125",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "106",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "015",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "044",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n211",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "051",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n039",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n049",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n091",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "013",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n037",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "051",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n125",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n193",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n095",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n042",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "146",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n039",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n001",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n167",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "090",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n068",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "045",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "114",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n175",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "016",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "095",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n117",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n082",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "032",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "018",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n182",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n164",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n023",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n209",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n067",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "070",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "118",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "072",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n057",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "097",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "093",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "054",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n181",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "037",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "040",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "091",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "046",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "036",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n077",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "103",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n146",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n078",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "003",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n182",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n132",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n059",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "104",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n036",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n174",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n109",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "098",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "127",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "084",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n107",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "120",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n213",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n098",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n023",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n120",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n034",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "026",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "035",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n043",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n063",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n197",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "004",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "025",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n101",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n007",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "103",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n071",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n161",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "045",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "136",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n118",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "082",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n111",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n095",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n140",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n211",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "090",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "108",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n029",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n043",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n190",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n075",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n201",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "028",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n062",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "014",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n053",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n205",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "085",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n045",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "041",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "138",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "081",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n081",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n143",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n054",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n158",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "064",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "028",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n024",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n168",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n175",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n199",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n022",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n013",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n191",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n129",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "020",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "108",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n106",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n131",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n036",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n102",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n048",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n161",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "075",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "102",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n128",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "053",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n017",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n209",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n076",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n203",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n100",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n088",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n134",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n193",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n006",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n155",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "134",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "001",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "130",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "057",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n143",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "137",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "073",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n015",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n140",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n136",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "057",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "081",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n108",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "032",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "006",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n035",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n073",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n220",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n131",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n220",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n002",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "026",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n208",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n008",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n141",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "063",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n184",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "048",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n004",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n178",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n136",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "066",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "085",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "038",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n124",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "116",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n099",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "138",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "021",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "034",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n071",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n074",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n211",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "019",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n099",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n010",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "141",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n154",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "121",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "148",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n075",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "034",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "033",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "065",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "139",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n162",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n170",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n118",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "083",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n012",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n047",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n045",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n206",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n216",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n153",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "074",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n159",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n079",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n192",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "082",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n026",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n181",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "113",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "011",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "024",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "079",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "021",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n196",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n092",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "025",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "003",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "076",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n146",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "079",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n040",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n051",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "008",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "116",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n184",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "077",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "085",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "042",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n005",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n027",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "150",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n168",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n072",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n080",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n190",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "107",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n094",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "069",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n086",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n202",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n187",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n167",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "073",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "145",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n058",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n148",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n031",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "091",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "057",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n038",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n013",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n076",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "044",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "043",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n112",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n032",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n203",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "024",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n129",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n016",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n100",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "030",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "027",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n044",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n163",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "083",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "020",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "082",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "105",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n126",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n134",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n150",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "124",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n176",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "007",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n017",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "111",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n055",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "001",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n208",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n032",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n165",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n116",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n198",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "056",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n173",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "128",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n186",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "068",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n058",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n172",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n069",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n138",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "102",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n064",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n148",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "037",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n162",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n024",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "061",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n111",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n021",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "090",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n096",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n149",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n097",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "002",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n005",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n207",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "149",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "101",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n197",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "117",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n069",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n113",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "092",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n107",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n034",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n153",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n083",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "040",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n097",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n185",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "004",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n172",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n187",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n039",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "086",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n209",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n010",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n184",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "131",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "132",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n197",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n054",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n195",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n212",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n121",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n204",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n065",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "053",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "038",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n144",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "017",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n108",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n205",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n192",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n024",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "048",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "075",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "124",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "137",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n050",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n214",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "147",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n050",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n105",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n030",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n019",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n219",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n031",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "098",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n164",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n121",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n191",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "146",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n065",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "145",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "046",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n033",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n124",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n066",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n217",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n007",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "039",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n072",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "150",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n035",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n110",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n166",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "112",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n219",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "117",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "049",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n033",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "144",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n093",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n103",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "112",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n100",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n160",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n212",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n210",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "069",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n216",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "055",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n048",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n006",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "032",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "048",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "132",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n097",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n051",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "054",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n109",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "086",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n164",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "030",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n031",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n085",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n096",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "067",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n110",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "064",
+          "role": "A"
+        }
+      ]
+    },
+    {
+      "week": 3,
+      "cells": [
+        {
+          "matrix": "newcomer",
+          "row_id": "n218",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n080",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "147",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "107",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n214",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n083",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n139",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "109",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "005",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n040",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n157",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n001",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n137",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "136",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "019",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n195",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n009",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "150",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "064",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "021",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "022",
+          "role": "C"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n139",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "060",
+          "role": "B"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "070",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "096",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n003",
+          "role": "B"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n018",
+          "role": "A"
+        },
+        {
+          "matrix": "newcomer",
+          "row_id": "n038",
+          "role": "C"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "018",
+          "role": "A"
+        },
+        {
+          "matrix": "expert",
+          "row_id": "077",
+          "role": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/runs/matrix-sampled/progress.json
+++ b/runs/matrix-sampled/progress.json
@@ -1,0 +1,30 @@
+{
+  "created_at": "2026-04-28T13:16:31Z",
+  "total_weeks": 3,
+  "weeks": [
+    {
+      "week": 1,
+      "cell_count": 540,
+      "status": "pending",
+      "started_at": null,
+      "completed_at": null,
+      "transcripts_dir": null
+    },
+    {
+      "week": 2,
+      "cell_count": 540,
+      "status": "pending",
+      "started_at": null,
+      "completed_at": null,
+      "transcripts_dir": null
+    },
+    {
+      "week": 3,
+      "cell_count": 30,
+      "status": "pending",
+      "started_at": null,
+      "completed_at": null,
+      "transcripts_dir": null
+    }
+  ]
+}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -155,6 +155,21 @@ Recompute and re-prompt if the user changes any of:
 
 If the user accepts: proceed to Phase 3. If the user wants to scale down (e.g. "use the sparse vector instead", "skip half the categories"), recompute the estimate against the new plan and re-prompt before dispatching.
 
+### When the matrix exceeds weekly budget
+
+If the planned run is over ~90% of the user's weekly Sonnet bucket, propose **partitioning into weekly samples** rather than scaling down or proceeding-with-overage. Use `tools/sample_matrix_run.py`:
+
+```bash
+python3 tools/sample_matrix_run.py init           # one-time, deterministic seed
+python3 tools/sample_matrix_run.py next-week      # writes runs/matrix-sampled/week-NN/scripts.json
+# … dispatch this week's scripts.json via Phase 3 …
+python3 tools/sample_matrix_run.py mark-completed --week NN
+```
+
+The tool flattens both matrices, shuffles once with a fixed seed, and partitions into non-overlapping weekly chunks sized to ~90% of the weekly Sonnet bucket. Each cell runs exactly once across N weeks. Default partition (3 weeks × 540 cells) covers all 1110 cells in three weekly resets.
+
+Each week's `scripts.json` is in the same shape Phase 3 dispatches consume, with `role` and `attack` already inlined per cell — the dispatch subagent prompt template just reads them through.
+
 ---
 
 ## Phase 3 — Run subagents
@@ -170,7 +185,7 @@ Workdir layout:
 
 Dispatch in **background batches** using `Agent` with `run_in_background: true`, `subagent_type: "general-purpose"`, and `model: "sonnet"`. The orchestrator running this skill stays on its default model (Opus); only the spawned subagents run on Sonnet — they're doing high-volume role-play of threat-model scenarios where the extra reasoning headroom over Haiku materially changes whether subtle attacks (homoglyph, approval-cloak, chain-swap) land convincingly enough to test the defense. The cost premium is accepted for this skill specifically; on Max x20 plans Sonnet usage is billed separately while Haiku is included, so this is a deliberate quality-over-cost choice for adversarial smoke testing.
 
-**Batch size is the orchestrator's call.** Pick what's optimal for the current run given: rate-limit headroom, target MCP latency, parent-context budget, and whether earlier batches surfaced systemic issues that warrant slowing down. Historically 10/batch has been a reasonable default, but don't treat it as fixed — go larger when the MCP is fast and rate limits are healthy, smaller when batches are throwing rate-limit errors or when you want to inspect early results before fanning out further.
+**Batch size is the orchestrator's call.** Pick what's optimal for the current run given: rate-limit headroom, target MCP latency, parent-context budget, and whether earlier batches surfaced systemic issues that warrant slowing down. **Default for Sonnet-mode runs: 15/batch** (slightly higher than the historical Haiku-tuned 10/batch, because Sonnet's per-call latency is somewhat higher and 15 keeps wall-clock manageable while staying under typical 5-hour-window TPM caps). Tune down to 10 or below on rate-limit errors; go higher only after early batches have completed cleanly. Sampled weekly runs from `tools/sample_matrix_run.py` carry the recommended batch size in their `scripts.json` `batch_size` field — read it from there.
 
 ### Honest mode prompt template
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -9,6 +9,35 @@ Helper scripts used during smoke-test runs. These are the little utilities the p
 | `parse_summary_adversarial.py` | Same as above, plus the `[ADVERSARIAL_RESULT]` block (role / attack / defense_layer / did_user_get_tricked) | Phase 5 step 5.2 (adversarial mode) |
 | `find_missing_transcripts.sh` | Diff between expected script IDs (from a `scripts.json`) and on-disk `transcripts/*.txt` — surfaces which subagents haven't completed yet | Phase 3 monitoring |
 | `wait_for_transcripts.sh` | Block until a target transcript count is reached. Designed for `Bash(run_in_background:true)` so the parent agent gets a single "all done" notification | Phase 3 / 4 transition |
+| `sample_matrix_run.py` | Partition the (expert + newcomer) matrix into weekly random samples that fit the Sonnet-weekly budget; track per-week progress so every cell runs exactly once across N weeks | Phase 2.5 (cost preflight) for matrix-mode runs |
+
+### `sample_matrix_run.py` — usage
+
+A full matrix run on both audiences is 1110 cells ≈ ~56M tokens, which exceeds the Max-x20 weekly Sonnet bucket. This tool partitions the work into non-overlapping weekly samples sized to fit ~90% of the weekly budget, with a fixed seed so the partition is deterministic.
+
+```bash
+# One-time: build the partition + progress files (already done if committed)
+python3 tools/sample_matrix_run.py init [--seed N] \
+    [--sonnet-weekly 30000000] [--fraction 0.9] \
+    [--per-cell 50000] [--batch-size 15]
+
+# Each week: get the next pending sample, writes runs/matrix-sampled/week-NN/scripts.json
+python3 tools/sample_matrix_run.py next-week
+
+# After dispatching + analyzing the week's run
+python3 tools/sample_matrix_run.py mark-completed --week N \
+    [--transcripts runs/matrix-sampled/week-NN/transcripts]
+
+# Anytime: see overall progress
+python3 tools/sample_matrix_run.py status
+```
+
+State files (under `runs/matrix-sampled/`):
+- `partition.json` — immutable plan; `init --force` to reshuffle from a new seed
+- `progress.json` — `pending | in_progress | completed` per week
+- `week-NN/scripts.json` — the cells dispatched that week, in the format the skill's Phase 3 dispatch consumes (one entry per cell, with role + attack inlined)
+
+Default budget (30M Sonnet weekly × 0.9 × 50k tokens/cell = 540 cells/week → 3 weeks for the full 1110-cell matrix). Override the budget args if your plan, model behavior, or the skill's per-cell anchor changes.
 
 ## Conventions
 

--- a/tools/sample_matrix_run.py
+++ b/tools/sample_matrix_run.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+tools/sample_matrix_run.py — Partition (expert + newcomer) matrix cells into
+weekly samples that fit a budget; track per-week run progress.
+
+Why this exists:
+  A full matrix run on both audiences is 1110 cells ≈ ~56M tokens, which
+  exceeds the Max-x20 weekly Sonnet bucket. Splitting across ~3 weeks with
+  random partitioning lets every cell run exactly once over time without any
+  single week blowing the budget.
+
+Sampling strategy:
+  - Flatten 1110 cells (450 expert + 660 newcomer, each × {A, B, C}).
+  - Shuffle once with a fixed seed (default 42) — partition is deterministic
+    and reproducible from the seed.
+  - Split into weekly chunks of N cells, where
+        N = floor(SONNET_WEEKLY × FRACTION / TOKENS_PER_CELL)
+    Defaults: SONNET_WEEKLY=30M, FRACTION=0.9, TOKENS_PER_CELL=50k → N=540.
+  - Weekly chunks are non-overlapping; they cumulatively cover every cell
+    exactly once.
+  - Per-batch dispatch (within a week's run) uses BATCH_SIZE concurrent
+    subagents — bounded by the per-session rate-limit, not the weekly budget.
+
+Subcommands:
+  init                   Create partition.json + progress.json (one-time).
+  next-week              Print the next pending week's cells and write its
+                         scripts.json under runs/matrix-sampled/week-NN/.
+                         Marks the week as in_progress.
+  mark-completed --week N [--transcripts PATH]
+                         Mark week N as completed, optionally record where
+                         its transcripts live.
+  status                 Show overall progress.
+
+Outputs (under runs/matrix-sampled/):
+  partition.json         Immutable plan — never edit by hand. Re-run
+                         `init --force` if you really need to reshuffle.
+  progress.json          Per-week status: pending | in_progress | completed.
+  week-NN/scripts.json   The cells dispatched that week, in the format
+                         expected by the skill's Phase 3 dispatch.
+"""
+import argparse
+import json
+import os
+import random
+import sys
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXPERT_PATH = f'{REPO}/test-vectors/expert-matrix.json'
+NEWCOMER_PATH = f'{REPO}/test-vectors/newcomer-matrix.json'
+SAMPLE_DIR = f'{REPO}/runs/matrix-sampled'
+PARTITION_PATH = f'{SAMPLE_DIR}/partition.json'
+PROGRESS_PATH = f'{SAMPLE_DIR}/progress.json'
+
+# Defaults align with skill/SKILL.md Phase 2.5 anchors. Override via flags
+# if the user's plan / model behavior changes.
+DEFAULT_SONNET_WEEKLY = 30_000_000
+DEFAULT_FRACTION = 0.9
+DEFAULT_TOKENS_PER_CELL = 50_000
+DEFAULT_BATCH_SIZE = 15
+DEFAULT_SEED = 42
+
+
+def _now() -> str:
+    return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+
+
+def _load_matrix_cells(path: str, label: str) -> list[dict]:
+    matrix = json.load(open(path))
+    cells = []
+    for row in matrix['rows']:
+        for role in ('A', 'B', 'C'):
+            cells.append({
+                'matrix': label,
+                'row_id': row['id'],
+                'role': role,
+            })
+    return cells
+
+
+def _flatten_all() -> list[dict]:
+    return _load_matrix_cells(EXPERT_PATH, 'expert') + \
+           _load_matrix_cells(NEWCOMER_PATH, 'newcomer')
+
+
+def cmd_init(args: argparse.Namespace) -> None:
+    if os.path.exists(PARTITION_PATH) and not args.force:
+        sys.exit(f"{PARTITION_PATH} already exists. Use --force to reshuffle.")
+
+    cells = _flatten_all()
+    rnd = random.Random(args.seed)
+    rnd.shuffle(cells)
+
+    cells_per_week = int(args.sonnet_weekly * args.fraction / args.per_cell)
+    if cells_per_week < 1:
+        sys.exit("derived cells_per_week < 1 — check your budget args")
+
+    weeks = [cells[i:i + cells_per_week]
+             for i in range(0, len(cells), cells_per_week)]
+
+    os.makedirs(SAMPLE_DIR, exist_ok=True)
+
+    partition = {
+        'created_at': _now(),
+        'seed': args.seed,
+        'cells_per_week': cells_per_week,
+        'budget_constraint': {
+            'sonnet_weekly_tokens': args.sonnet_weekly,
+            'budget_fraction': args.fraction,
+            'tokens_per_cell': args.per_cell,
+            'derived_cells_per_week': cells_per_week,
+        },
+        'batch_size': args.batch_size,
+        'total_cells': len(cells),
+        'total_weeks': len(weeks),
+        'weeks': [{'week': i + 1, 'cells': w} for i, w in enumerate(weeks)],
+    }
+    with open(PARTITION_PATH, 'w') as f:
+        json.dump(partition, f, indent=2)
+
+    progress = {
+        'created_at': partition['created_at'],
+        'total_weeks': len(weeks),
+        'weeks': [
+            {
+                'week': i + 1,
+                'cell_count': len(w),
+                'status': 'pending',
+                'started_at': None,
+                'completed_at': None,
+                'transcripts_dir': None,
+            }
+            for i, w in enumerate(weeks)
+        ],
+    }
+    with open(PROGRESS_PATH, 'w') as f:
+        json.dump(progress, f, indent=2)
+
+    print(f"wrote {PARTITION_PATH}")
+    print(f"  total cells:        {partition['total_cells']}")
+    print(f"  cells/week:         {partition['cells_per_week']}")
+    print(f"  total weeks:        {partition['total_weeks']}")
+    print(f"  estimated tokens/week: ~{cells_per_week * args.per_cell / 1e6:.1f}M")
+    print(f"  batch size:         {partition['batch_size']}")
+    print(f"  seed:               {partition['seed']}")
+
+
+def cmd_next_week(args: argparse.Namespace) -> None:
+    if not os.path.exists(PROGRESS_PATH):
+        sys.exit("No partition yet. Run `init` first.")
+    progress = json.load(open(PROGRESS_PATH))
+    partition = json.load(open(PARTITION_PATH))
+
+    pending = [w for w in progress['weeks'] if w['status'] == 'pending']
+    if not pending:
+        in_prog = [w for w in progress['weeks'] if w['status'] == 'in_progress']
+        if in_prog:
+            print(f"week {in_prog[0]['week']} already in_progress — "
+                  f"finish it (mark-completed) before starting next.")
+        else:
+            print("All weeks completed.")
+        return
+
+    week_n = pending[0]['week']
+    week_cells = next(w['cells'] for w in partition['weeks']
+                      if w['week'] == week_n)
+
+    expert = json.load(open(EXPERT_PATH))
+    newcomer = json.load(open(NEWCOMER_PATH))
+    expert_by_id = {r['id']: r for r in expert['rows']}
+    newcomer_by_id = {r['id']: r for r in newcomer['rows']}
+
+    hydrated = []
+    for c in week_cells:
+        row = (expert_by_id if c['matrix'] == 'expert'
+               else newcomer_by_id)[c['row_id']]
+        hydrated.append({
+            'id': f"{c['matrix']}-{c['row_id']}-{c['role']}",
+            'matrix': c['matrix'],
+            'row_id': c['row_id'],
+            'role': c['role'],
+            'category': row['category'],
+            'chain': row.get('chain'),
+            'script': row['script'],
+            'attack': row['cells'][c['role']],
+        })
+
+    week_dir = f'{SAMPLE_DIR}/week-{week_n:02d}'
+    os.makedirs(week_dir, exist_ok=True)
+    scripts_path = f'{week_dir}/scripts.json'
+
+    out = {
+        '_comment': (
+            f'Week {week_n} of {progress["total_weeks"]} — '
+            f'{len(hydrated)} cells dispatched in this run. '
+            'Schema is the same shape Phase 3 of skill/SKILL.md expects, '
+            'with role + attack added per script for the adversarial '
+            'subagent prompt template.'
+        ),
+        'week': week_n,
+        'batch_size': partition['batch_size'],
+        'addressBook': expert.get('addressBook', {}),
+        'roleLegend': expert.get('roleLegend', {}),
+        'scripts': hydrated,
+    }
+    with open(scripts_path, 'w') as f:
+        json.dump(out, f, indent=2)
+
+    pending[0]['status'] = 'in_progress'
+    pending[0]['started_at'] = _now()
+    with open(PROGRESS_PATH, 'w') as f:
+        json.dump(progress, f, indent=2)
+
+    matrix_counts = {'expert': 0, 'newcomer': 0}
+    role_counts = {'A': 0, 'B': 0, 'C': 0}
+    for c in hydrated:
+        matrix_counts[c['matrix']] += 1
+        role_counts[c['role']] += 1
+    est_tokens = len(hydrated) * partition['budget_constraint']['tokens_per_cell']
+
+    print(f"wrote {scripts_path}")
+    print(f"  cells:              {len(hydrated)}")
+    print(f"  by matrix:          {matrix_counts}")
+    print(f"  by role:            {role_counts}")
+    print(f"  recommended batch:  {partition['batch_size']}")
+    print(f"  est. dispatch cost: ~{est_tokens / 1e6:.1f}M tokens")
+    print(f"  next: dispatch via skill/SKILL.md Phase 3, "
+          f"then `mark-completed --week {week_n}`")
+
+
+def cmd_mark_completed(args: argparse.Namespace) -> None:
+    if not os.path.exists(PROGRESS_PATH):
+        sys.exit("No partition yet. Run `init` first.")
+    progress = json.load(open(PROGRESS_PATH))
+    week = next((w for w in progress['weeks'] if w['week'] == args.week), None)
+    if not week:
+        sys.exit(f"Week {args.week} not in partition (have weeks 1..{progress['total_weeks']}).")
+    week['status'] = 'completed'
+    week['completed_at'] = _now()
+    if args.transcripts:
+        week['transcripts_dir'] = args.transcripts
+    with open(PROGRESS_PATH, 'w') as f:
+        json.dump(progress, f, indent=2)
+    print(f"week {args.week} marked completed at {week['completed_at']}")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    if not os.path.exists(PROGRESS_PATH):
+        sys.exit("No partition yet. Run `init` first.")
+    progress = json.load(open(PROGRESS_PATH))
+    counts = {'completed': 0, 'in_progress': 0, 'pending': 0}
+    for w in progress['weeks']:
+        counts[w['status']] += 1
+    print(f"weeks: {progress['total_weeks']}  "
+          f"(completed={counts['completed']}  "
+          f"in_progress={counts['in_progress']}  "
+          f"pending={counts['pending']})")
+    for w in progress['weeks']:
+        marker = {'completed': '[X]', 'in_progress': '[.]', 'pending': '[ ]'}[w['status']]
+        started = w.get('started_at') or '—'
+        completed = w.get('completed_at') or '—'
+        print(f"  {marker} week {w['week']:02d}  {w['cell_count']:>4} cells  "
+              f"{w['status']:12s}  started={started}  completed={completed}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    p_init = sub.add_parser('init', help='Create the partition (one-time).')
+    p_init.add_argument('--seed', type=int, default=DEFAULT_SEED)
+    p_init.add_argument('--sonnet-weekly', dest='sonnet_weekly',
+                        type=int, default=DEFAULT_SONNET_WEEKLY,
+                        help='Sonnet weekly budget in tokens (default: 30M)')
+    p_init.add_argument('--fraction', type=float, default=DEFAULT_FRACTION,
+                        help='Fraction of weekly budget to use (default: 0.9)')
+    p_init.add_argument('--per-cell', dest='per_cell',
+                        type=int, default=DEFAULT_TOKENS_PER_CELL,
+                        help='Tokens per cell estimate (default: 50k)')
+    p_init.add_argument('--batch-size', dest='batch_size',
+                        type=int, default=DEFAULT_BATCH_SIZE,
+                        help='Concurrent subagents per dispatch batch (default: 15)')
+    p_init.add_argument('--force', action='store_true',
+                        help='Overwrite existing partition.json + progress.json')
+    p_init.set_defaults(func=cmd_init)
+
+    p_next = sub.add_parser('next-week',
+                            help='Print and persist next pending week.')
+    p_next.set_defaults(func=cmd_next_week)
+
+    p_mark = sub.add_parser('mark-completed', help='Mark a week as run.')
+    p_mark.add_argument('--week', type=int, required=True)
+    p_mark.add_argument('--transcripts', help='Path to transcripts dir.')
+    p_mark.set_defaults(func=cmd_mark_completed)
+
+    p_stat = sub.add_parser('status', help='Show progress.')
+    p_stat.set_defaults(func=cmd_status)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

A full matrix adversarial run on both audiences is **1110 cells ≈ ~56M tokens**, which exceeds the Max-x20 weekly Sonnet bucket (~30M). Rather than scaling the matrix down or proceeding with overage, this PR partitions the matrix into **non-overlapping weekly random samples** sized to ~90% of the weekly budget; every cell runs exactly once across N weeks.

## What ships

- **`tools/sample_matrix_run.py`** — `init` (deterministic seed shuffle), `next-week` (emits `week-NN/scripts.json` in the format Phase 3 dispatch consumes), `mark-completed`, `status`. Default partition is **540 cells/week × 3 weeks**, derived from `30M Sonnet weekly × 0.9 budget fraction × 50k tokens/cell`. All defaults overridable via flags.
- **`runs/matrix-sampled/partition.json` + `progress.json`** — pre-initialized with seed 42 so the user can `next-week` straight away without running `init`.
- **`tools/README.md`** — entry + usage block.
- **`skill/SKILL.md` Phase 2.5** — points at the tool when a planned run exceeds the weekly budget.
- **`skill/SKILL.md` Phase 3** — Sonnet batch-size guidance: **default 15/batch** (up from the legacy Haiku 10/batch), with the rationale (Sonnet's higher per-call latency) and tuning instructions. Notes that sampled weekly runs carry `batch_size` in their emitted `scripts.json`.

## Why this design

- **Random shuffle, fixed seed.** Deterministic and reproducible; rerunning `init` from the same seed produces the same partition. `init --force` to reshuffle.
- **Non-overlapping by construction.** A single `cells[]` list is shuffled once, then sliced — no overlap between weekly chunks, no gaps.
- **90% Sonnet weekly cap.** Stays under the user's weekly bucket with margin for Phase 5 analysis subagent costs and Opus orchestrator overhead.
- **Per-batch fits one session.** 15 cells × 50k = 750k tokens per batch — comfortably inside any 5-hour-window TPM cap, which is the constraint the user flagged.
- **Progress survives across sessions.** `progress.json` records `pending | in_progress | completed` per week, so resuming is just `next-week`.

## Run shape after this PR

```
$ python3 tools/sample_matrix_run.py status
weeks: 3  (completed=0  in_progress=0  pending=3)
  [ ] week 01   540 cells  pending
  [ ] week 02   540 cells  pending
  [ ] week 03    30 cells  pending

$ python3 tools/sample_matrix_run.py next-week
wrote runs/matrix-sampled/week-01/scripts.json
  cells:              540
  by matrix:          {'expert': 219, 'newcomer': 321}
  by role:            {'A': 184, 'B': 176, 'C': 180}
  recommended batch:  15
  est. dispatch cost: ~27.0M tokens
```

## Test plan

- [x] `init` creates partition + progress; partition matches budget math (540 cells/week × 3 weeks)
- [x] `init --force` overwrites cleanly
- [x] `next-week` emits a Phase-3-shaped `scripts.json` with `role` + `attack` inlined per cell, marks week as in_progress
- [x] Across the 3 weeks, the cells partition every (matrix, row_id, role) tuple exactly once (verified by random spot-check)
- [x] Role + matrix distribution per week is approximately uniform (random shuffle)
- [ ] First end-to-end weekly run: `next-week` → dispatch → `mark-completed` → re-run `next-week` advances to week 2 (deferred to first real run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)