### PR TITLE
Add per-batch feedback loop (auto-aggregate + findings + issue-filing)

### DIFF
--- a/runs/matrix-sampled/partition.json
+++ b/runs/matrix-sampled/partition.json
@@ -1,5 +1,5 @@
 {
-  "created_at": "2026-04-28T14:16:05Z",
+  "created_at": "2026-04-28T14:34:53Z",
   "seed": 42,
   "batch_size": 50,
   "budget_constraint": {

--- a/runs/matrix-sampled/progress.json
+++ b/runs/matrix-sampled/progress.json
@@ -1,5 +1,5 @@
 {
-  "created_at": "2026-04-28T14:16:05Z",
+  "created_at": "2026-04-28T14:34:53Z",
   "total_batches": 23,
   "batches": [
     {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -157,18 +157,32 @@ If the user accepts: proceed to Phase 3. If the user wants to scale down (e.g. "
 
 ### When the matrix exceeds session / weekly budget
 
-If the planned run is over the user's available weekly Sonnet or 5-hour all-models capacity, propose **partitioning into batches** rather than scaling down or proceeding-with-overage. Use `tools/sample_matrix_run.py`:
+If the planned run is over the user's available weekly Sonnet or 5-hour all-models capacity, propose **partitioning into batches** rather than scaling down or proceeding-with-overage. Use `tools/sample_matrix_run.py` and run the per-batch loop:
 
 ```bash
-python3 tools/sample_matrix_run.py init             # one-time, deterministic seed
-python3 tools/sample_matrix_run.py next-batch       # writes runs/matrix-sampled/batch-NN/scripts.json
-# … dispatch this batch's scripts.json via Phase 3 …
-python3 tools/sample_matrix_run.py mark-completed --batch NN
+python3 tools/sample_matrix_run.py init                 # one-time, deterministic seed
+python3 tools/sample_matrix_run.py next-batch           # cost preflight + writes batch-NN/scripts.json
+# … 1. dispatch (Phase 3) over batch-NN/scripts.json …
+python3 tools/sample_matrix_run.py mark-completed --batch NN   # 2. auto-aggregates transcripts
+# … 3. orchestrator delegates analysis subagent → batch-NN/findings.md …
+# … 4. orchestrator drafts issues from findings → files via gh, records in batch-NN/issues.md …
 ```
 
 The tool flattens both matrices, shuffles once with a fixed seed, and slices into fixed-size batches sized to fill ~50% of one 5-hour all-models session (default 50 cells / ~2.5M tokens per batch → 23 batches for the full 1110-cell matrix). The user decides how many batches to dispatch per week / per session — the tool just hands them the next pending batch and counts overall progress.
 
 Each batch's `scripts.json` is in the same shape Phase 3 dispatches consume, with `role` and `attack` already inlined per cell. Dispatch all cells in the batch concurrently (the batch IS the dispatch unit) — no further per-batch sub-batching needed.
+
+### Per-batch feedback loop (mandatory after each batch dispatch)
+
+After dispatch finishes for a batch, run `mark-completed --batch N`. That auto-runs the **quick aggregate** (step 2 below). The orchestrator then runs steps 3 and 4 before moving on:
+
+1. **Dispatch** (Phase 3) — handled above.
+2. **Auto-aggregate** — `mark-completed` runs this for you. Parses `batch-NN/transcripts/*.txt` → writes `batch-NN/summary.txt` and `batch-NN/aggregate.json`. Surfaces structural counts: by role, by defense layer (which invariant caught the attack, or `none`), and `did_user_get_tricked` (yes/no/n/a). The "tricked: yes" SCRIPT_IDs are flagged in the console output — those are the urgent ones.
+3. **Per-batch findings.md** — orchestrator delegates a fresh analysis subagent (`model: "sonnet"`) over `batch-NN/summary.txt`. Use the canonical Phase 5 analysis prompt, scoped to "this batch's 50 cells". Persist the subagent's reply as `batch-NN/findings.md`. A 50-cell sample is small for full pattern recognition — this analysis is intentionally scoped to "what's surfacing in *this* batch" rather than a corpus-wide assessment.
+4. **File issues from this batch's findings** — read `batch-NN/findings.md`, draft GitHub issues for each distinct finding (skill, intent-layer gaps, on-device blind-sign risks, MCP bugs surfaced). File via `gh issue create` per Phase 6 conventions; record the resulting URLs in `batch-NN/issues.md`. Confirm with the user before bulk-filing — first issue surface, ask approval, then proceed.
+5. **(Optional) Cumulative analysis** — once enough batches have run that cross-batch patterns matter, run a full Phase 5 analysis over the union of all `batch-NN/summary.txt` files. This is the existing "findings.md across the run" lens. Skip by default; run it explicitly when the user asks for a cross-batch synthesis.
+
+Why per-batch instead of one final cumulative analysis: matrix runs span weeks, and waiting until the end to surface findings means defense gaps stay open while the user is still dispatching against them. Per-batch analysis lets the user catch a systemic failure on batch 2 and stop dispatching the remaining 21 batches against a broken defense.
 
 ---
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -27,20 +27,33 @@ python3 tools/sample_matrix_run.py init [--seed N] \
 # total progress).
 python3 tools/sample_matrix_run.py next-batch
 
-# After dispatching the batch
+# After dispatching the batch — auto-aggregates transcripts, surfaces counts
+# (by role, by defense layer, did_user_get_tricked), flags tricked SCRIPT_IDs,
+# and prints next-step instructions for the orchestrator (analysis +
+# issue-filing).
 python3 tools/sample_matrix_run.py mark-completed --batch N \
-    [--transcripts runs/matrix-sampled/batch-NN/transcripts]
+    [--transcripts <path>]      # default: runs/matrix-sampled/batch-NN/transcripts
+    [--skip-aggregate]          # skip the auto-aggregate step
+
+# Re-run the aggregate on its own (e.g. if mark-completed was called before
+# transcripts landed, or you fixed up transcripts and want to refresh)
+python3 tools/sample_matrix_run.py aggregate-batch --batch N
 
 # Anytime: see overall progress
 python3 tools/sample_matrix_run.py status [-v]
 ```
 
-The `next-batch` output is the Phase 2.5 cost preflight report — surface it to the user verbatim and wait for confirmation before dispatching.
+The `next-batch` output is the Phase 2.5 cost preflight report — surface it to the user verbatim and wait for confirmation before dispatching. The `mark-completed` output is the quick aggregate — surface the counts to the user and act on the next-step instructions (delegate analysis subagent, file issues).
 
 State files (under `runs/matrix-sampled/`):
 - `partition.json` — immutable plan; `init --force` to reshuffle from a new seed
 - `progress.json` — `pending | in_progress | completed` per batch
-- `batch-NN/scripts.json` — the cells dispatched in batch N, in the format the skill's Phase 3 dispatch consumes (one entry per cell, with role + attack inlined)
+- `batch-NN/scripts.json` — input: cells dispatched in batch N (Phase 3 format)
+- `batch-NN/transcripts/*.txt` — output of dispatch (one per cell)
+- `batch-NN/summary.txt` — auto-extracted structured records (after `mark-completed`)
+- `batch-NN/aggregate.json` — auto-extracted counts (after `mark-completed`)
+- `batch-NN/findings.md` — orchestrator's per-batch analysis (manual; see skill Phase 3.6)
+- `batch-NN/issues.md` — orchestrator's per-batch issue-filing record (manual; see skill Phase 3.7)
 
 Default partition: 50 cells/batch × 23 batches = 1110 cells. Override budget anchors via flags if your plan changes; `--batch-size` overrides the auto-derived value if you want a different fill ratio.
 

--- a/tools/sample_matrix_run.py
+++ b/tools/sample_matrix_run.py
@@ -38,8 +38,10 @@ import argparse
 import json
 import os
 import random
+import re
 import sys
 import time
+from collections import Counter
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 EXPERT_PATH = f'{REPO}/test-vectors/expert-matrix.json'
@@ -267,6 +269,119 @@ def cmd_next_batch(args: argparse.Namespace) -> None:
           f"over {scripts_path}, then `mark-completed --batch {batch_n}`.")
 
 
+def _parse_transcripts(transcripts_dir: str) -> list[dict]:
+    """Parse adversarial transcripts -> structured records (mirrors
+    tools/parse_summary_adversarial.py)."""
+    records = []
+    for fn in sorted(os.listdir(transcripts_dir)):
+        if not fn.endswith('.txt'):
+            continue
+        text = open(os.path.join(transcripts_dir, fn)).read()
+        rec = {'file': fn}
+        for k in ('SCRIPT_ID', 'ROLE', 'ATTACK', 'CATEGORY', 'CHAIN', 'SCRIPT'):
+            m = re.search(rf'^{k}:\s*(.+)$', text, re.M)
+            if m:
+                val = m.group(1).strip()
+                # Skill template puts the header on one line as
+                # "SCRIPT_ID: ID | CATEGORY: ... | CHAIN: ... | SCRIPT: ..."
+                # — split on " | " for non-SCRIPT fields so we don't
+                # capture the trailing fields.
+                if k != 'SCRIPT' and ' | ' in val:
+                    val = val.split(' | ')[0].strip()
+                rec[k.lower()] = val
+        m = re.search(r'\[OUTCOME\](.*?)(?=\[OBSERVATIONS\]|\[ADVERSARIAL_RESULT\]|\Z)',
+                      text, re.S)
+        rec['outcome'] = (m.group(1).strip() if m else '').replace('\n', ' ')[:300]
+        m = re.search(r'\[ADVERSARIAL_RESULT\](.*?)(?=={3,}|\Z)', text, re.S)
+        rec['adv'] = (m.group(1).strip() if m else '')[:1500]
+        # Extract structured fields from inside the ADVERSARIAL_RESULT block.
+        m_def = re.search(r'defense[_ ]layer[_a-z ]*:\s*(.+?)(?:\n|$)', rec['adv'], re.I)
+        m_tricked = re.search(r'did[_ ]user[_ ]get[_ ]tricked:\s*(.+?)(?:\n|$)', rec['adv'], re.I)
+        m_attempt = re.search(r'attack[_ ]attempted:\s*(.+?)(?:\n|$)', rec['adv'], re.I)
+        rec['defense_layer'] = m_def.group(1).strip() if m_def else 'unknown'
+        rec['did_user_get_tricked'] = m_tricked.group(1).strip().lower() if m_tricked else 'unknown'
+        rec['attack_attempted'] = m_attempt.group(1).strip() if m_attempt else ''
+        records.append(rec)
+    return records
+
+
+def _aggregate_batch(batch_n: int, transcripts_dir: str | None = None,
+                    quiet: bool = False) -> dict | None:
+    """Run the quick aggregate over a batch's transcripts. Writes
+    summary.txt + aggregate.json under runs/matrix-sampled/batch-NN/.
+    Returns the aggregate dict, or None if no transcripts found."""
+    batch_dir = f'{SAMPLE_DIR}/batch-{batch_n:02d}'
+    if transcripts_dir is None:
+        transcripts_dir = f'{batch_dir}/transcripts'
+    if not os.path.isdir(transcripts_dir):
+        if not quiet:
+            print(f"  (transcripts dir {transcripts_dir} not found — "
+                  f"skipping aggregate)")
+        return None
+
+    records = _parse_transcripts(transcripts_dir)
+    if not records:
+        if not quiet:
+            print(f"  (no transcripts in {transcripts_dir} — skipping aggregate)")
+        return None
+
+    summary_path = f'{batch_dir}/summary.txt'
+    with open(summary_path, 'w') as o:
+        for r in records:
+            sid = r.get('script_id', r['file'].replace('.txt', ''))
+            role = r.get('role', '?')
+            o.write(f"=== {sid} | role:{role} | {r.get('category','?')} ===\n")
+            if 'script' in r:
+                o.write(f"SCRIPT: {r['script'][:200]}\n")
+            if 'attack' in r:
+                o.write(f"ATTACK: {r['attack'][:200]}\n")
+            if r.get('outcome'):
+                o.write(f"OUTCOME: {r['outcome']}\n")
+            o.write(f"ADVERSARIAL_RESULT:\n{r['adv'][:1500]}\n\n")
+
+    by_layer = Counter(r['defense_layer'] for r in records)
+    by_tricked = Counter(r['did_user_get_tricked'] for r in records)
+    by_role = Counter(r.get('role', '?') for r in records)
+    tricked = by_tricked.get('yes', 0)
+
+    aggregate = {
+        'batch': batch_n,
+        'total_transcripts': len(records),
+        'by_defense_layer': dict(by_layer),
+        'by_did_user_get_tricked': dict(by_tricked),
+        'by_role': dict(by_role),
+        'tricked_count': tricked,
+        'tricked_script_ids': [r.get('script_id', r['file'].replace('.txt', ''))
+                               for r in records
+                               if r['did_user_get_tricked'] == 'yes'],
+    }
+    aggregate_path = f'{batch_dir}/aggregate.json'
+    with open(aggregate_path, 'w') as f:
+        json.dump(aggregate, f, indent=2)
+
+    if not quiet:
+        print(f"  wrote {summary_path}")
+        print(f"  wrote {aggregate_path}")
+        print(f"  transcripts:          {len(records)}")
+        print(f"  by role:              {dict(by_role)}")
+        print(f"  by defense layer:     {dict(by_layer)}")
+        print(f"  did_user_get_tricked: {dict(by_tricked)}")
+        if tricked:
+            print(f"  ⚠ {tricked} transcripts where user got tricked: "
+                  f"{aggregate['tricked_script_ids'][:5]}"
+                  f"{'...' if tricked > 5 else ''}")
+    return aggregate
+
+
+def cmd_aggregate_batch(args: argparse.Namespace) -> None:
+    """Standalone aggregate command — useful if mark-completed was called
+    before transcripts landed, or to re-aggregate after fixing transcripts."""
+    print(f"Aggregating batch {args.batch}...")
+    agg = _aggregate_batch(args.batch, transcripts_dir=args.transcripts)
+    if agg is None:
+        sys.exit(1)
+
+
 def cmd_mark_completed(args: argparse.Namespace) -> None:
     if not os.path.exists(PROGRESS_PATH):
         sys.exit("No partition yet. Run `init` first.")
@@ -283,6 +398,21 @@ def cmd_mark_completed(args: argparse.Namespace) -> None:
     with open(PROGRESS_PATH, 'w') as f:
         json.dump(progress, f, indent=2)
     print(f"batch {args.batch} marked completed at {batch['completed_at']}")
+
+    if not args.skip_aggregate:
+        print()
+        print(f"Auto-aggregating batch {args.batch}...")
+        agg = _aggregate_batch(args.batch, transcripts_dir=args.transcripts)
+        if agg is not None:
+            batch_dir = f'{SAMPLE_DIR}/batch-{args.batch:02d}'
+            print()
+            print(f"Next steps (orchestrator):")
+            print(f"  1. Per-batch findings: delegate analysis subagent over")
+            print(f"     {batch_dir}/summary.txt → write {batch_dir}/findings.md")
+            print(f"  2. File issues: draft GitHub issues from findings.md and")
+            print(f"     file via gh; record URLs in {batch_dir}/issues.md")
+            print(f"  3. (Optional) cumulative analysis once enough batches "
+                  f"have run.")
 
 
 def cmd_status(args: argparse.Namespace) -> None:
@@ -337,10 +467,21 @@ def main() -> None:
                             help='Print and persist next pending batch.')
     p_next.set_defaults(func=cmd_next_batch)
 
-    p_mark = sub.add_parser('mark-completed', help='Mark a batch as run.')
+    p_mark = sub.add_parser('mark-completed',
+                            help='Mark a batch as run; auto-aggregates transcripts.')
     p_mark.add_argument('--batch', type=int, required=True)
-    p_mark.add_argument('--transcripts', help='Path to transcripts dir.')
+    p_mark.add_argument('--transcripts', help='Path to transcripts dir '
+                                              '(default: runs/matrix-sampled/batch-NN/transcripts).')
+    p_mark.add_argument('--skip-aggregate', action='store_true',
+                        help="Don't auto-run the aggregate step.")
     p_mark.set_defaults(func=cmd_mark_completed)
+
+    p_agg = sub.add_parser('aggregate-batch',
+                           help='Re-run the quick aggregate over a batch.')
+    p_agg.add_argument('--batch', type=int, required=True)
+    p_agg.add_argument('--transcripts', help='Path to transcripts dir '
+                                             '(default: runs/matrix-sampled/batch-NN/transcripts).')
+    p_agg.set_defaults(func=cmd_aggregate_batch)
 
     p_stat = sub.add_parser('status', help='Show progress.')
     p_stat.add_argument('-v', '--verbose', action='store_true',


### PR DESCRIPTION
## Summary

After each batch dispatch, three things now happen:

1. **Auto-aggregate** (mechanical, by tool) — `mark-completed --batch N` parses transcripts, writes `summary.txt` + `aggregate.json`, surfaces counts (role / defense layer / did_user_get_tricked) and flags tricked SCRIPT_IDs.
2. **Per-batch findings.md** (orchestrator delegates analysis subagent) — fresh Sonnet analysis subagent over the batch's `summary.txt`. Scoped to *this* batch.
3. **File issues** (orchestrator) — read `findings.md`, draft GitHub issues, file via `gh`, record URLs in `batch-NN/issues.md`.

**Cumulative analysis** (the original Phase 5) is now explicitly optional — run it on the union of `summary.txt` files when cross-batch synthesis is warranted.

## Why per-batch instead of one final cumulative analysis

Matrix runs span weeks. Waiting until the end to surface findings means defense gaps stay open while the user is still dispatching against them. Per-batch analysis lets the user catch a systemic failure on batch 2 and stop dispatching the remaining 21 batches against a broken defense.

## Behavior change for `mark-completed`

Before:
```
batch 1 marked completed at 2026-04-28T14:31:57Z
```

After:
```
batch 1 marked completed at 2026-04-28T14:31:57Z

Auto-aggregating batch 1...
  wrote batch-01/summary.txt
  wrote batch-01/aggregate.json
  transcripts:          2
  by role:              {'A': 2}
  by defense layer:     {'preflight invariant 4': 1, 'none': 1}
  did_user_get_tricked: {'no': 1, 'yes': 1}
  ⚠ 1 transcripts where user got tricked: ['newcomer-n067-A']

Next steps (orchestrator):
  1. Per-batch findings: delegate analysis subagent over
     batch-01/summary.txt → write batch-01/findings.md
  2. File issues: draft GitHub issues from findings.md and
     file via gh; record URLs in batch-01/issues.md
  3. (Optional) cumulative analysis once enough batches have run.
```

Pass `--skip-aggregate` to defer; standalone `aggregate-batch --batch N` to re-run later.

## Implementation notes

- Aggregator reuses the parsing logic from `tools/parse_summary_adversarial.py` (inlined into `sample_matrix_run.py` since we need the structured records to compute counts beyond what the standalone parser produces).
- New `aggregate-batch` subcommand for re-running the aggregate (e.g. if `mark-completed` was called before transcripts landed, or transcripts were fixed).
- SKILL.md gets new sub-phases 3.6 (per-batch findings) and 3.7 (per-batch issue-filing) explicitly documented.
- tools/README.md updated with the per-batch loop layout.

## Test plan

- [x] `mark-completed --batch N` auto-runs aggregator on test transcripts
- [x] Console output shows counts + flags tricked SCRIPT_IDs
- [x] `--skip-aggregate` defers
- [x] Standalone `aggregate-batch --batch N` works
- [x] `summary.txt` and `aggregate.json` written under `batch-NN/`
- [x] Pre-committed `partition.json` / `progress.json` reset to clean state (no leftover test batches)
- [ ] First end-to-end run with real transcripts (deferred to first real batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)