### PR TITLE
Skill: auto-enable demo mode when MCP supports it

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -46,6 +46,16 @@ Before generating scripts, capture:
 
 If the MCP has a real-funds / signing surface, **always run in demo / sandbox mode**. Never broadcast real transactions during a smoke test.
 
+### Auto-enable demo mode when the MCP supports it
+
+If the target MCP exposes an in-session demo toggle (e.g. `vaultpilot-mcp`'s `set_demo_wallet` / `VAULTPILOT_DEMO=true` env var), the orchestrator must:
+
+1. **Probe the current state** before Phase 3 dispatch — call the MCP's status tool (`get_demo_wallet`, `get_vaultpilot_config_status`, or equivalent) and check whether demo / sandbox mode is active.
+2. **If demo is OFF, auto-enable it** rather than asking the user every time. Pick a persona that maximizes coverage for the planned scripts (for `vaultpilot-mcp`, `defi-degen` covers EVM + Solana + TRON DeFi flows). Surface what was enabled and why, then proceed.
+3. **If the MCP has no demo toggle** but has a real-funds surface, refuse to dispatch and propose narrowing to read-only scripts only (or have the user enable demo through whatever means the MCP supports — e.g. restart with env var).
+
+Auto-enabling is the right default because the user has already opted into smoke testing this MCP — having to confirm demo mode each batch is busywork. The orchestrator should still **report** what it did ("activated demo persona X for this session") so the action is visible. If the user prefers a different persona or wants to opt out, they can override before the next `next-batch`.
+
 ---
 
 ## Phase 2 — Generate the script catalog


### PR DESCRIPTION
## Summary

The skill mandates "always run in demo / sandbox mode" but didn't prescribe who enables it. This adds a concrete rule under Phase 1: if the target MCP exposes an in-session demo toggle (e.g. `vaultpilot-mcp`'s `set_demo_wallet` / `VAULTPILOT_DEMO=true`), the orchestrator probes state first and **auto-enables** demo if needed, picking a persona that maximizes coverage for the planned scripts (`defi-degen` for vaultpilot EVM + Solana + TRON DeFi). It reports what was enabled but doesn't ask for explicit confirmation each batch — the user already opted into testing this MCP.

## Why auto, not ask

Asking for demo-mode confirmation on every batch is busywork the user has already implicitly cleared by running smoke tests against this MCP. The orchestrator surfaces what it did ("activated persona X") so the action is visible; if the user wants a different persona or to opt out, they can say so before the next `next-batch`.

## Scope

- If the MCP has an in-session demo toggle → auto-enable.
- If the MCP has no demo toggle but has a real-funds surface → **refuse** to dispatch; propose read-only-only or user-side enablement.
- If the MCP has no real-funds surface (read-only data feeds) → no demo mode needed; existing "honest mode only" guidance still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)