### PR TITLE
Switch Phase 5 analysis subagent to Opus + add Opus weekly bucket to cost preflight

### DIFF
--- a/runs/matrix-sampled/partition.json
+++ b/runs/matrix-sampled/partition.json
@@ -1,12 +1,14 @@
 {
-  "created_at": "2026-04-28T16:08:00Z",
+  "created_at": "2026-04-28T17:15:20Z",
   "seed": 42,
   "batch_size": 50,
   "budget_constraint": {
     "sonnet_weekly_tokens": 30000000,
+    "opus_weekly_tokens": 10000000,
     "all_models_weekly_tokens": 50000000,
     "session_all_models_tokens": 5000000,
     "tokens_per_cell": 50000,
+    "analysis_tokens": 250000,
     "batch_session_fraction": 0.5
   },
   "total_cells": 1110,

--- a/runs/matrix-sampled/progress.json
+++ b/runs/matrix-sampled/progress.json
@@ -1,13 +1,13 @@
 {
-  "created_at": "2026-04-28T16:08:00Z",
+  "created_at": "2026-04-28T17:15:20Z",
   "total_batches": 23,
   "batches": [
     {
       "batch": 1,
       "cell_count": 50,
       "status": "completed",
-      "started_at": "2026-04-28T16:20:20Z",
-      "completed_at": "2026-04-28T16:35:25Z",
+      "started_at": null,
+      "completed_at": "2026-04-28T17:15:30Z",
       "transcripts_dir": null
     },
     {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -139,9 +139,10 @@ Worked example — adversarial run on `expert-matrix.json` (450 cells):
 
 ### Ballpark against Max x20 weekly tiers
 
-Max x20 has two relevant weekly buckets that this run consumes:
-- **Sonnet-only weekly bucket**: ballpark **~25–35M tokens/week** (this is where the dispatched subagents land — they're pinned to Sonnet).
-- **All-models weekly bucket** (cross-model, includes Opus orchestrator + Sonnet subagents + any Haiku/other usage): ballpark **~40–60M tokens/week**.
+Max x20 has three relevant weekly buckets that this run consumes:
+- **Sonnet-only weekly bucket**: ballpark **~25–35M tokens/week** (where dispatched per-cell subagents land — pinned to Sonnet per Phase 3).
+- **Opus weekly bucket**: ballpark **~8–12M tokens/week** (where the Phase 5 analysis subagent lands — pinned to Opus per Phase 5 step 5.3, plus orchestrator overhead since the orchestrator runs on Opus by default). Smallest bucket; binding constraint for analysis-heavy runs.
+- **All-models weekly bucket** (cross-model, includes Opus orchestrator + Sonnet subagents + Opus analyses + any Haiku/other usage): ballpark **~40–60M tokens/week**.
 
 These anchors are approximate — Anthropic's plan structure evolves; verify against the user's account dashboard for exact current numbers if it matters. The skill's job is **order-of-magnitude awareness**, not authoritative billing.
 
@@ -191,7 +192,7 @@ After dispatch finishes for a batch, run `mark-completed --batch N`. That auto-r
 
 1. **Dispatch** (Phase 3) — handled above.
 2. **Auto-aggregate** — `mark-completed` runs this for you. Parses `batch-NN/transcripts/*.txt` → writes `batch-NN/summary.txt` and `batch-NN/aggregate.json`. Surfaces structural counts: by role, by defense layer (which invariant caught the attack, or `none`), and `did_user_get_tricked` (yes/no/n/a). The "tricked: yes" SCRIPT_IDs are flagged in the console output — those are the urgent ones.
-3. **Per-batch findings.md + issues.draft.json** — orchestrator delegates a fresh analysis subagent (`model: "sonnet"`) over `batch-NN/summary.txt`. Use the canonical Phase 5 analysis prompt, scoped to "this batch's N cells". The subagent emits TWO artifacts:
+3. **Per-batch findings.md + issues.draft.json** — orchestrator delegates a fresh analysis subagent (`model: "opus"`) over `batch-NN/summary.txt`. Use the canonical Phase 5 analysis prompt, scoped to "this batch's N cells". The subagent emits TWO artifacts:
    - `batch-NN/findings.md` — analyst-readable prose (sections 1–6 from the Phase 5 prompt).
    - `batch-NN/issues.draft.json` — machine-readable issue list, one entry per `# Filing recommendations` finding from §6 of `findings.md`. Schema:
      ```json
@@ -335,7 +336,7 @@ Optionally produce a structured per-script summary with a small Python script ex
 
 ## Phase 5 — Analyze
 
-Delegate to a **fresh subagent** (clean context) using `Agent` with `model: "sonnet"`. As in Phase 3, the orchestrator stays on Opus; only the spawned analysis subagent runs on Sonnet — analysis quality matters here (the corpus is large, the patterns are subtle), and the same Max-x20 billing rationale from Phase 3 applies.
+Delegate to a **fresh subagent** (clean context) using `Agent` with `model: "opus"`. The dispatched per-cell subagents run on Sonnet (Phase 3); the analysis subagent is upgraded to Opus because it does cross-corpus pattern recognition over 50+ transcripts at once and the upgrade materially changes whether subtle multi-cell patterns (Role-C structural risks, layered invariant gaps, education-frame-then-exploit chains) are surfaced. The cost is one Opus run per batch (~250k input + ~10k output ≈ ~260k Opus tokens); see Phase 2.5 for how this lands against the Max-x20 Opus weekly bucket.
 
 ### How exactly to analyze the chat histories (concrete recipe — don't skip)
 

--- a/tools/sample_matrix_run.py
+++ b/tools/sample_matrix_run.py
@@ -52,9 +52,11 @@ PROGRESS_PATH = f'{SAMPLE_DIR}/progress.json'
 
 # Defaults align with skill/SKILL.md Phase 2.5 anchors.
 DEFAULT_SONNET_WEEKLY = 30_000_000
+DEFAULT_OPUS_WEEKLY = 10_000_000  # Phase 5 analysis subagent runs on Opus; smallest bucket
 DEFAULT_ALL_MODELS_WEEKLY = 50_000_000
 DEFAULT_SESSION_ALL_MODELS = 5_000_000  # 5-hour all-models cap, override via flag
 DEFAULT_TOKENS_PER_CELL = 50_000
+DEFAULT_ANALYSIS_TOKENS = 250_000  # one Phase 5 Opus analysis subagent run per batch
 DEFAULT_BATCH_SESSION_FRACTION = 0.5  # batch fills this much of one 5-hour session
 DEFAULT_SEED = 42
 
@@ -107,9 +109,11 @@ def cmd_init(args: argparse.Namespace) -> None:
         'batch_size': batch_size,
         'budget_constraint': {
             'sonnet_weekly_tokens': args.sonnet_weekly,
+            'opus_weekly_tokens': args.opus_weekly,
             'all_models_weekly_tokens': args.all_models_weekly,
             'session_all_models_tokens': args.session_all_models,
             'tokens_per_cell': args.per_cell,
+            'analysis_tokens': args.analysis_tokens,
             'batch_session_fraction': DEFAULT_BATCH_SESSION_FRACTION,
         },
         'total_cells': len(cells),
@@ -140,23 +144,30 @@ def cmd_init(args: argparse.Namespace) -> None:
     with open(PROGRESS_PATH, 'w') as f:
         json.dump(progress, f, indent=2)
 
-    per_batch_tokens = batch_size * args.per_cell
-    pct_batch_sonnet = per_batch_tokens / args.sonnet_weekly * 100
-    pct_batch_all = per_batch_tokens / args.all_models_weekly * 100
-    pct_batch_session = per_batch_tokens / args.session_all_models * 100
+    dispatch_tokens = batch_size * args.per_cell        # Sonnet
+    analysis_tokens = args.analysis_tokens              # Opus
+    per_batch_total = dispatch_tokens + analysis_tokens
+    pct_batch_sonnet = dispatch_tokens / args.sonnet_weekly * 100
+    pct_batch_opus = analysis_tokens / args.opus_weekly * 100
+    pct_batch_all = per_batch_total / args.all_models_weekly * 100
+    pct_batch_session = per_batch_total / args.session_all_models * 100
 
     print(f"wrote {PARTITION_PATH}")
     print(f"  total cells:     {partition['total_cells']}")
-    print(f"  batch size:      {batch_size} cells = ~{per_batch_tokens / 1e6:.2f}M tokens")
+    print(f"  batch size:      {batch_size} cells = "
+          f"~{dispatch_tokens / 1e6:.2f}M Sonnet (dispatch) + "
+          f"~{analysis_tokens / 1e6:.2f}M Opus (analysis)")
     print(f"  total batches:   {partition['total_batches']}")
     print()
     print(f"Per batch vs Max-20x caps:")
     print(f"  Sonnet weekly:       ~{pct_batch_sonnet:.1f}% of bucket "
-          f"(anchor ~{args.sonnet_weekly / 1e6:.0f}M)")
+          f"(anchor ~{args.sonnet_weekly / 1e6:.0f}M)  [dispatch only]")
+    print(f"  Opus weekly:         ~{pct_batch_opus:.1f}% of bucket "
+          f"(anchor ~{args.opus_weekly / 1e6:.0f}M)  [analysis only]")
     print(f"  All-models weekly:   ~{pct_batch_all:.1f}% of bucket "
-          f"(anchor ~{args.all_models_weekly / 1e6:.0f}M)")
+          f"(anchor ~{args.all_models_weekly / 1e6:.0f}M)  [dispatch + analysis]")
     print(f"  All-models session:  ~{pct_batch_session:.1f}% of bucket "
-          f"(anchor ~{args.session_all_models / 1e6:.0f}M)")
+          f"(anchor ~{args.session_all_models / 1e6:.0f}M)  [dispatch + analysis]")
     print(f"  seed: {partition['seed']}")
 
 
@@ -232,13 +243,17 @@ def cmd_next_batch(args: argparse.Namespace) -> None:
     bc = partition['budget_constraint']
     per_cell = bc['tokens_per_cell']
     sonnet_weekly = bc['sonnet_weekly_tokens']
+    opus_weekly = bc.get('opus_weekly_tokens', DEFAULT_OPUS_WEEKLY)
     all_models_weekly = bc.get('all_models_weekly_tokens', DEFAULT_ALL_MODELS_WEEKLY)
     session_all_models = bc.get('session_all_models_tokens', DEFAULT_SESSION_ALL_MODELS)
+    analysis_tokens = bc.get('analysis_tokens', DEFAULT_ANALYSIS_TOKENS)
 
-    per_batch_tokens = len(hydrated) * per_cell
-    pct_batch_sonnet = per_batch_tokens / sonnet_weekly * 100
-    pct_batch_all = per_batch_tokens / all_models_weekly * 100
-    pct_batch_session = per_batch_tokens / session_all_models * 100
+    dispatch_tokens = len(hydrated) * per_cell                # Sonnet
+    per_batch_total = dispatch_tokens + analysis_tokens       # Sonnet + Opus
+    pct_batch_sonnet = dispatch_tokens / sonnet_weekly * 100
+    pct_batch_opus = analysis_tokens / opus_weekly * 100
+    pct_batch_all = per_batch_total / all_models_weekly * 100
+    pct_batch_session = per_batch_total / session_all_models * 100
 
     total_batches = progress['total_batches']
     batches_done = sum(1 for b in progress['batches']
@@ -250,20 +265,23 @@ def cmd_next_batch(args: argparse.Namespace) -> None:
     print(f"Sample:   {len(hydrated)} cells "
           f"(expert: {matrix_counts['expert']}, newcomer: {matrix_counts['newcomer']}; "
           f"A: {role_counts['A']}, B: {role_counts['B']}, C: {role_counts['C']})")
-    print(f"Tokens:   ~{per_batch_tokens / 1e6:.2f}M for this batch")
+    print(f"Tokens:   ~{dispatch_tokens / 1e6:.2f}M Sonnet (dispatch) + "
+          f"~{analysis_tokens / 1e6:.2f}M Opus (Phase 5 analysis)")
     print(f"Progress: {batches_done} / {total_batches} batches done")
     print()
     print(f"Per batch vs Max-20x caps:")
     print(f"  Sonnet weekly:       ~{pct_batch_sonnet:.1f}% of bucket "
-          f"(anchor ~{sonnet_weekly / 1e6:.0f}M)")
+          f"(anchor ~{sonnet_weekly / 1e6:.0f}M)  [dispatch only]")
+    print(f"  Opus weekly:         ~{pct_batch_opus:.1f}% of bucket "
+          f"(anchor ~{opus_weekly / 1e6:.0f}M)  [analysis only]")
     print(f"  All-models weekly:   ~{pct_batch_all:.1f}% of bucket "
-          f"(anchor ~{all_models_weekly / 1e6:.0f}M)")
+          f"(anchor ~{all_models_weekly / 1e6:.0f}M)  [dispatch + analysis]")
     print(f"  All-models session:  ~{pct_batch_session:.1f}% of bucket "
-          f"(anchor ~{session_all_models / 1e6:.0f}M)")
+          f"(anchor ~{session_all_models / 1e6:.0f}M)  [dispatch + analysis]")
     print()
     print(f"Rough estimates — verify on your account dashboard. Override "
-          f"anchors via `init --sonnet-weekly`, `--all-models-weekly`, "
-          f"`--session-all-models`.")
+          f"anchors via `init --sonnet-weekly`, `--opus-weekly`, "
+          f"`--all-models-weekly`, `--session-all-models`.")
     print()
     print(f"Next: orchestrator confirms with user, then dispatch Phase 3 "
           f"over {scripts_path}, then `mark-completed --batch {batch_n}`.")
@@ -522,6 +540,10 @@ def main() -> None:
     p_init.add_argument('--sonnet-weekly', dest='sonnet_weekly',
                         type=int, default=DEFAULT_SONNET_WEEKLY,
                         help='Sonnet weekly budget in tokens (default: 30M)')
+    p_init.add_argument('--opus-weekly', dest='opus_weekly',
+                        type=int, default=DEFAULT_OPUS_WEEKLY,
+                        help='Opus weekly budget in tokens (default: 10M); '
+                             'Phase 5 analysis subagent runs on Opus, one per batch')
     p_init.add_argument('--all-models-weekly', dest='all_models_weekly',
                         type=int, default=DEFAULT_ALL_MODELS_WEEKLY,
                         help='All-models weekly budget in tokens (default: 50M)')
@@ -531,6 +553,10 @@ def main() -> None:
     p_init.add_argument('--per-cell', dest='per_cell',
                         type=int, default=DEFAULT_TOKENS_PER_CELL,
                         help='Tokens per cell estimate (default: 50k)')
+    p_init.add_argument('--analysis-tokens', dest='analysis_tokens',
+                        type=int, default=DEFAULT_ANALYSIS_TOKENS,
+                        help='Phase 5 analysis subagent token estimate '
+                             '(default: 250k; runs on Opus)')
     p_init.add_argument('--batch-size', dest='batch_size',
                         type=int, default=None,
                         help='Concurrent subagents per batch '


### PR DESCRIPTION
## Summary

**Per-cell dispatch subagents (50/batch) stay on Sonnet.** High-volume adversarial role-play where Sonnet's reasoning is sufficient and the Sonnet weekly bucket can absorb the volume.

**Phase 5 analysis subagent (1/batch) moves Sonnet → Opus.** Cross-corpus pattern recognition over 50+ transcripts materially benefits from Opus — the analyst surfaces multi-cell structural risks (Role-C suppression chains, education-frame-then-exploit chains, layered invariant gaps) that Sonnet can miss in synthesis. One Opus run per batch is small relative to the Opus weekly bucket.

## Cost preflight changes

Init + next-batch now print **4 cap lines** instead of 3:

```
Per batch vs Max-20x caps:
  Sonnet weekly:       ~8.3% of bucket (anchor ~30M)  [dispatch only]
  Opus weekly:         ~2.5% of bucket (anchor ~10M)  [analysis only]
  All-models weekly:   ~5.5% of bucket (anchor ~50M)  [dispatch + analysis]
  All-models session:  ~55.0% of bucket (anchor ~5M)  [dispatch + analysis]
```

- New constant `DEFAULT_OPUS_WEEKLY = 10M` (placeholder, override via `--opus-weekly`).
- `DEFAULT_ANALYSIS_TOKENS = 250k` restored (was dropped in the earlier per-batch-only simplification; needed back for the Opus column).
- All-models columns now include analysis tokens (previously only dispatch was counted; analysis was implicit).
- Each cap line annotated with what it counts (`[dispatch only]`, `[analysis only]`, `[dispatch + analysis]`).

## Skill changes

- **Phase 3.6** (per-batch findings) — `model: "sonnet"` → `model: "opus"` for the analyzer.
- **Phase 5 step 5.4** — same model swap + rationale ("cross-corpus pattern recognition over 50+ transcripts at once").
- **Phase 2.5** — weekly tier section now lists three buckets (Sonnet ~25–35M, Opus ~8–12M, all-models ~40–60M) and notes Opus is the smallest bucket and binding constraint for analysis-heavy runs.

## State

Pre-committed `runs/matrix-sampled/{partition,progress}.json` refreshed to include `opus_weekly_tokens` + `analysis_tokens` fields. Batch-1's completed status preserved (`mark-completed --batch 1 --skip-aggregate` after `init --force` since init resets progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)