### PR TITLE
Lane 4: /run-batch slash command + auto-commit helper

### DIFF
--- a/.claude/commands/run-batch.md
+++ b/.claude/commands/run-batch.md
@@ -1,0 +1,51 @@
+---
+description: Run one full smoke-test batch end-to-end (preflight → dispatch → analyze → file → commit). Two user gates only.
+---
+
+# /run-batch — autonomous smoke-test batch
+
+Runs the next pending batch of the vaultpilot-mcp adversarial smoke test through the full 6-phase pipeline (per `skill/SKILL.md`, soon `CLAUDE.md` per Lane 2). One slash invocation, two manual user gates, everything else automatic.
+
+## Manual gates (the only places you'll be asked anything)
+
+1. **Cost preflight gate.** After `next-batch` prints the per-batch role distribution + Opus analysis cost + filing target, you'll be asked for explicit OK on this specific batch. A "go" on batch N does NOT carry over to batch N+1 (per CLAUDE.md).
+2. **Filing dry-run gate.** After Phase 5 produces `findings.md` + `issues.draft.json`, the filer dry-runs and surfaces the planned issue titles + label sets. You'll be asked one OK on the full set; on OK, all issues file in one go.
+
+## Steps the orchestrator follows verbatim
+
+1. **`python3 tools/sample_matrix_run.py next-batch`** — writes `runs/matrix-sampled/batch-NN/scripts.json`, prints the cost preflight block, marks batch in_progress.
+2. **GATE 1 — surface preflight, ask user.** Format the cost preflight as a markdown table (sample, role distribution, A.5/C.5 share, E control share, Haiku throughput, Opus analysis cost, wall-clock estimate, filing target). Ask: "Explicit OK to dispatch all N cells?". Wait for affirmative.
+3. **`touch runs/matrix-sampled/batch-NN/.preflight-confirmed`** — stamp file. Lane 3's PreToolUse hook checks for this; without it, `Agent` calls are blocked.
+4. **Dispatch.** Read full cell list from `runs/matrix-sampled/batch-NN/scripts.json`. Spawn parallel `Agent` calls in waves of 25 (single message per wave with 25 tool_use blocks): `subagent_type: general-purpose`, `model: haiku`, prompt = adversarial-mode template with `{id, role, category, chain, script, attack}` substituted. Each subagent uses its own Write tool to save its transcript at `runs/matrix-sampled/batch-NN/transcripts/{id}.txt`; reply is just `wrote <path>`.
+5. **`python3 tools/sample_matrix_run.py verify-transcripts --batch NN --repair`** — checks every transcript has the literal `[ADVERSARIAL_RESULT]` header; auto-repairs if missing.
+6. **`python3 tools/sample_matrix_run.py mark-completed --batch NN`** — marks completed in `progress.json` and auto-runs the aggregate (writes `summary.txt` + `aggregate.json`).
+7. **Phase 5 analysis subagent.** Spawn one `Agent` call: `subagent_type: general-purpose`, `model: opus`, prompt = canonical Phase 5 prompt (filling in `<MCP-NAME>` and `<workdir>`). Subagent reads `summary.txt` + selectively reads `transcripts/*.txt` + cross-references prior-batch findings. Returns markdown analysis + a fenced ```json-issues-draft``` block.
+8. **Persist analysis.** Parent agent writes the markdown to `runs/matrix-sampled/batch-NN/findings.md` and the JSON to `runs/matrix-sampled/batch-NN/issues.draft.json`.
+9. **`python3 tools/file_batch_issues.py --batch NN --repo szhygulin/vaultpilot-mcp --dry-run`** — preview the planned `gh issue create` calls.
+10. **GATE 2 — surface dry-run summary, ask user.** Show the planned issue titles + label sets in a markdown table. Ask: "OK to file all N issues against szhygulin/vaultpilot-mcp?". Wait for affirmative.
+11. **`python3 tools/file_batch_issues.py --batch NN --repo szhygulin/vaultpilot-mcp`** — files all issues, appends URLs to `runs/matrix-sampled/batch-NN/issues.md`.
+12. **`tools/post_batch_commit.sh NN`** — branches (`batch-NN-results`), commits batch-NN artifacts + `progress.json`, pushes, opens PR.
+13. **Report final summary.** Tell the user: batches done, issue URLs filed, PR URL.
+
+## What you DON'T need to confirm during this flow
+
+- Each individual Agent dispatch (covered by the preflight stamp + Lane 3 hook).
+- `verify-transcripts --repair` (deterministic auto-fix, idempotent).
+- `mark-completed` (no side effects beyond local files).
+- Phase 5 Opus analyst spawn (one call, ~82k tokens, already in the cost preflight).
+- Each individual `gh issue create` call (covered by GATE 2's full-set OK).
+- Branch + commit + push + PR-open (auto on this repo per CLAUDE.md "never push to main"; auto-commits go to a feature branch).
+
+## What to do if a step fails
+
+- **`Agent` call blocked by preflight hook (Lane 3):** the stamp file is missing or the user wasn't asked. Surface the cost preflight, get OK, `touch` the stamp, retry.
+- **`verify-transcripts --repair` reports failures it can't fix:** stop and surface the failing transcripts to the user. Don't silently drop them; offer revert (re-run the cell, accept synthesized minimal block, or skip with explicit acknowledgement).
+- **Phase 5 analysis subagent returns malformed JSON:** parse-then-show-the-user; ask whether to re-run or hand-edit `issues.draft.json`.
+- **`gh issue create` fails on a label:** the label isn't on the target repo. Surface the missing label name; user creates it (or you propose a substitute) before retry.
+- **`tools/post_batch_commit.sh` fails on push (e.g. main branch protection violation):** never force; surface the error, the user resolves manually.
+
+## When NOT to use this command
+
+- One-off experimentation that doesn't follow the standard 50-cell batch flow.
+- Re-running a batch that's already in `completed` status (you'd want `aggregate-batch` only, then re-trigger Phase 5 manually).
+- Filing into a different repo than `szhygulin/vaultpilot-mcp` (override with `--repo` flag once you reach the filing step).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx tsc --noEmit *)",
+      "Bash(npm run lint *)",
+      "mcp__vaultpilot-mcp__get_transaction_history",
+      "mcp__vaultpilot-mcp__preview_send",
+      "mcp__vaultpilot-mcp__prepare_token_send",
+      "mcp__vaultpilot-mcp__get_transaction_status",
+      "mcp__vaultpilot-mcp__prepare_custom_call",
+
+      "Bash(python3 tools/sample_matrix_run.py *)",
+      "Bash(python3 tools/file_batch_issues.py --batch * --repo szhygulin/vaultpilot-mcp *)",
+      "Bash(python3 tools/file_batch_issues.py --batch * --repo szhygulin/vaultpilot-mcp)",
+      "Bash(python3 test-vectors/build_*matrix.py)",
+      "Bash(python3 test-vectors/build_matrix.py)",
+      "Bash(touch runs/matrix-sampled/batch-*/.preflight-confirmed)",
+      "Bash(tools/post_batch_commit.sh *)",
+      "Bash(./tools/post_batch_commit.sh *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.tmp
 __pycache__/
 node_modules/
-.claude/
+# .claude/ is project methodology (settings.json, commands/, hooks/) — track it.
+# Only the per-developer local-overrides file is ignored.
+.claude/settings.local.json

--- a/tools/post_batch_commit.sh
+++ b/tools/post_batch_commit.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# tools/post_batch_commit.sh — auto-commit + push + PR for a completed smoke-test batch.
+#
+# Usage: tools/post_batch_commit.sh <batch_number>
+#
+# Effects:
+#   1. Creates branch `batch-<NN>-results` (NN zero-padded; never main per CLAUDE.md).
+#   2. Stages and commits runs/matrix-sampled/batch-<NN>/ + progress.json.
+#   3. Pushes the branch with -u to set upstream.
+#   4. Opens a PR with title + body templated from aggregate.json + findings.md.
+#
+# This script is idempotent in the sense that re-running on the same batch
+# (already committed) will fail at `git checkout -b` and the user can resolve
+# manually. We DO NOT force-push or amend — every batch gets its own branch.
+#
+# Exits non-zero on any error (set -e). Caller (the /run-batch slash command)
+# surfaces failures to the user.
+
+set -euo pipefail
+
+batch="${1:-}"
+if [[ -z "$batch" ]]; then
+    echo "Usage: $0 <batch_number>" >&2
+    exit 1
+fi
+pad=$(printf '%02d' "$batch")
+batch_dir="runs/matrix-sampled/batch-${pad}"
+
+if [[ ! -d "$batch_dir" ]]; then
+    echo "ERROR: $batch_dir does not exist." >&2
+    exit 1
+fi
+if [[ ! -f "$batch_dir/aggregate.json" ]]; then
+    echo "ERROR: $batch_dir/aggregate.json missing — has Phase 4 mark-completed run?" >&2
+    exit 1
+fi
+if [[ ! -f "$batch_dir/findings.md" ]]; then
+    echo "ERROR: $batch_dir/findings.md missing — has Phase 5 analyst run?" >&2
+    exit 1
+fi
+if [[ ! -f "$batch_dir/issues.md" ]]; then
+    echo "ERROR: $batch_dir/issues.md missing — has Phase 6 filer run?" >&2
+    exit 1
+fi
+
+# Extract headline numbers for the commit message + PR title.
+total=$(jq -r '.total_transcripts' "$batch_dir/aggregate.json")
+tricked=$(jq -r '.tricked_count' "$batch_dir/aggregate.json")
+filed=$(grep -c '^| [0-9]' "$batch_dir/issues.md" || echo 0)
+roles=$(jq -r '.by_role | to_entries | map("\(.key): \(.value)") | join(", ")' "$batch_dir/aggregate.json")
+
+branch="batch-${pad}-results"
+if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+    echo "ERROR: branch $branch already exists. Resolve manually." >&2
+    exit 1
+fi
+
+git checkout -b "$branch"
+git add "$batch_dir/" runs/matrix-sampled/progress.json
+
+git commit -m "$(cat <<EOF
+batch-${batch} results: ${total} cells, ${tricked} user-tricked, ${filed} issues filed
+
+Roles: ${roles}
+
+Artifacts:
+- ${batch_dir}/scripts.json — dispatched cells
+- ${batch_dir}/transcripts/ — per-cell reports
+- ${batch_dir}/summary.txt — structured summary
+- ${batch_dir}/aggregate.json — counters
+- ${batch_dir}/findings.md — Phase 5 markdown analysis
+- ${batch_dir}/issues.draft.json — drafted issues
+- ${batch_dir}/issues.md — filing log with URLs
+EOF
+)"
+
+git push -u origin "$branch"
+
+# PR body: paste findings.md (it's the canonical analysis already).
+gh pr create \
+    --title "batch-${batch} results: ${total} cells, ${tricked} tricked, ${filed} issues filed" \
+    --body-file "$batch_dir/findings.md"
+
+echo "post_batch_commit.sh complete: branch=$branch"


### PR DESCRIPTION
## Summary

PR 1 of 4 in the smoke-test pipeline overhaul (per `/home/szhygulin/.claude/plans/smoke-test-overhaul-4-lanes.md`). Reduces a batch run from ~6 manual checkpoints to 2.

## What ships

- **`.claude/commands/run-batch.md`** — slash-command recipe with 13 numbered steps; 2 explicit user gates (cost preflight + filing OK); troubleshooting section.
- **`tools/post_batch_commit.sh`** — branch + commit + push + PR helper. Templates headline numbers from `aggregate.json`; attaches `findings.md` as the PR body. Never pushes to main (per CLAUDE.md).
- **`.claude/settings.json`** — pre-approved bash patterns for the helpers.
- **`.gitignore`** — track `.claude/` (project methodology); ignore only `.claude/settings.local.json` (per-developer).

## The 2 manual gates (and what gets bypassed)

| Gate | When | Why |
|---|---|---|
| **GATE 1: Cost preflight** | After `next-batch` prints role distribution + costs | Per-CLAUDE.md mandatory rule; Lane 3 (next PR) will physically enforce via PreToolUse hook |
| **GATE 2: Filing dry-run** | After Phase 5 + `file_batch_issues.py --dry-run` | GitHub-visible action against an external repo (vaultpilot-mcp) — explicit OK before publishing |

Bypassed during autonomous flow: each Agent dispatch (50 of them per batch), `verify-transcripts --repair`, `mark-completed`, Phase 5 spawn, each individual `gh issue create`, branch+commit+push+PR.

## Integration points for later lanes

- **Lane 3** adds a PreToolUse hook that checks `runs/matrix-sampled/batch-NN/.preflight-confirmed` before allowing `Agent` calls. The `touch` step in `/run-batch` (after GATE 1 OK) is the integration point.
- **Lane 1** (no silent skips) will add `parse_failures` array; Lane 4's flow is unchanged but the verify-transcripts step gains stronger surfacing.
- **Lane 2** moves skill content into CLAUDE.md; this PR's slash command currently references `skill/SKILL.md` but will work seamlessly after the move.

## Test plan

- [x] `git diff --cached` shows only Lane 4 files (parser fix and batch-02 results stay on separate branches).
- [x] `.claude/settings.json` is tracked; `.claude/settings.local.json` remains gitignored.
- [x] `post_batch_commit.sh` is `chmod +x` and shellcheck-clean (set -euo pipefail, defensive existence checks).
- [ ] First post-merge `/run-batch` invocation will exercise the full flow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)