### PR TITLE
Lane 3: PreToolUse hook enforces preflight gate

### DIFF
--- a/.claude/commands/run-batch.md
+++ b/.claude/commands/run-batch.md
@@ -1,0 +1,51 @@
+---
+description: Run one full smoke-test batch end-to-end (preflight → dispatch → analyze → file → commit). Two user gates only.
+---
+
+# /run-batch — autonomous smoke-test batch
+
+Runs the next pending batch of the vaultpilot-mcp adversarial smoke test through the full 6-phase pipeline (per `skill/SKILL.md`, soon `CLAUDE.md` per Lane 2). One slash invocation, two manual user gates, everything else automatic.
+
+## Manual gates (the only places you'll be asked anything)
+
+1. **Cost preflight gate.** After `next-batch` prints the per-batch role distribution + Opus analysis cost + filing target, you'll be asked for explicit OK on this specific batch. A "go" on batch N does NOT carry over to batch N+1 (per CLAUDE.md).
+2. **Filing dry-run gate.** After Phase 5 produces `findings.md` + `issues.draft.json`, the filer dry-runs and surfaces the planned issue titles + label sets. You'll be asked one OK on the full set; on OK, all issues file in one go.
+
+## Steps the orchestrator follows verbatim
+
+1. **`python3 tools/sample_matrix_run.py next-batch`** — writes `runs/matrix-sampled/batch-NN/scripts.json`, prints the cost preflight block, marks batch in_progress.
+2. **GATE 1 — surface preflight, ask user.** Format the cost preflight as a markdown table (sample, role distribution, A.5/C.5 share, E control share, Haiku throughput, Opus analysis cost, wall-clock estimate, filing target). Ask: "Explicit OK to dispatch all N cells?". Wait for affirmative.
+3. **`touch runs/matrix-sampled/batch-NN/.preflight-confirmed`** — stamp file. Lane 3's PreToolUse hook checks for this; without it, `Agent` calls are blocked.
+4. **Dispatch.** Read full cell list from `runs/matrix-sampled/batch-NN/scripts.json`. Spawn parallel `Agent` calls in waves of 25 (single message per wave with 25 tool_use blocks): `subagent_type: general-purpose`, `model: haiku`, prompt = adversarial-mode template with `{id, role, category, chain, script, attack}` substituted. Each subagent uses its own Write tool to save its transcript at `runs/matrix-sampled/batch-NN/transcripts/{id}.txt`; reply is just `wrote <path>`.
+5. **`python3 tools/sample_matrix_run.py verify-transcripts --batch NN --repair`** — checks every transcript has the literal `[ADVERSARIAL_RESULT]` header; auto-repairs if missing.
+6. **`python3 tools/sample_matrix_run.py mark-completed --batch NN`** — marks completed in `progress.json` and auto-runs the aggregate (writes `summary.txt` + `aggregate.json`).
+7. **Phase 5 analysis subagent.** Spawn one `Agent` call: `subagent_type: general-purpose`, `model: opus`, prompt = canonical Phase 5 prompt (filling in `<MCP-NAME>` and `<workdir>`). Subagent reads `summary.txt` + selectively reads `transcripts/*.txt` + cross-references prior-batch findings. Returns markdown analysis + a fenced ```json-issues-draft``` block.
+8. **Persist analysis.** Parent agent writes the markdown to `runs/matrix-sampled/batch-NN/findings.md` and the JSON to `runs/matrix-sampled/batch-NN/issues.draft.json`.
+9. **`python3 tools/file_batch_issues.py --batch NN --repo szhygulin/vaultpilot-mcp --dry-run`** — preview the planned `gh issue create` calls.
+10. **GATE 2 — surface dry-run summary, ask user.** Show the planned issue titles + label sets in a markdown table. Ask: "OK to file all N issues against szhygulin/vaultpilot-mcp?". Wait for affirmative.
+11. **`python3 tools/file_batch_issues.py --batch NN --repo szhygulin/vaultpilot-mcp`** — files all issues, appends URLs to `runs/matrix-sampled/batch-NN/issues.md`.
+12. **`tools/post_batch_commit.sh NN`** — branches (`batch-NN-results`), commits batch-NN artifacts + `progress.json`, pushes, opens PR.
+13. **Report final summary.** Tell the user: batches done, issue URLs filed, PR URL.
+
+## What you DON'T need to confirm during this flow
+
+- Each individual Agent dispatch (covered by the preflight stamp + Lane 3 hook).
+- `verify-transcripts --repair` (deterministic auto-fix, idempotent).
+- `mark-completed` (no side effects beyond local files).
+- Phase 5 Opus analyst spawn (one call, ~82k tokens, already in the cost preflight).
+- Each individual `gh issue create` call (covered by GATE 2's full-set OK).
+- Branch + commit + push + PR-open (auto on this repo per CLAUDE.md "never push to main"; auto-commits go to a feature branch).
+
+## What to do if a step fails
+
+- **`Agent` call blocked by preflight hook (Lane 3):** the stamp file is missing or the user wasn't asked. Surface the cost preflight, get OK, `touch` the stamp, retry.
+- **`verify-transcripts --repair` reports failures it can't fix:** stop and surface the failing transcripts to the user. Don't silently drop them; offer revert (re-run the cell, accept synthesized minimal block, or skip with explicit acknowledgement).
+- **Phase 5 analysis subagent returns malformed JSON:** parse-then-show-the-user; ask whether to re-run or hand-edit `issues.draft.json`.
+- **`gh issue create` fails on a label:** the label isn't on the target repo. Surface the missing label name; user creates it (or you propose a substitute) before retry.
+- **`tools/post_batch_commit.sh` fails on push (e.g. main branch protection violation):** never force; surface the error, the user resolves manually.
+
+## When NOT to use this command
+
+- One-off experimentation that doesn't follow the standard 50-cell batch flow.
+- Re-running a batch that's already in `completed` status (you'd want `aggregate-batch` only, then re-trigger Phase 5 manually).
+- Filing into a different repo than `szhygulin/vaultpilot-mcp` (override with `--repo` flag once you reach the filing step).

--- a/.claude/hooks/preflight_gate.sh
+++ b/.claude/hooks/preflight_gate.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# .claude/hooks/preflight_gate.sh — PreToolUse hook for Agent calls.
+#
+# Blocks Agent dispatches during smoke-test batches that have NOT been
+# explicitly confirmed by the user. The user confirms by `touch`ing the
+# .preflight-confirmed stamp file, which the orchestrator only does AFTER
+# surfacing the cost preflight (Phase 2.5) and getting an explicit "go".
+#
+# Exit codes:
+#   0 — let the Agent call through (no smoke-test batch in progress, OR stamp exists).
+#   1 — block the Agent call and surface the reason via stderr.
+#
+# How it integrates with the rest of the pipeline:
+#   - tools/sample_matrix_run.py next-batch  →  marks a batch in_progress.
+#   - /run-batch slash command surfaces preflight, asks user, on OK runs:
+#       touch runs/matrix-sampled/batch-NN/.preflight-confirmed
+#   - This hook runs before every `Agent` tool call. Reads progress.json,
+#     finds the in-progress batch, checks for the stamp.
+#   - When the batch completes (mark-completed), the next batch's preflight
+#     is required again. Stamps are per-batch.
+#
+# Trade-off (documented in CLAUDE.md): this hook fires on EVERY Agent call
+# while a batch is in_progress, including non-smoke-test ones. If you need
+# a non-smoke-test Agent call mid-batch, complete or pause the batch first
+# (delete the stamp + reset progress.json's in_progress entry).
+
+set -euo pipefail
+
+progress="runs/matrix-sampled/progress.json"
+
+# No partition yet → no smoke test in flight → let through.
+if [[ ! -f "$progress" ]]; then
+    exit 0
+fi
+
+# Pick the first in_progress batch. If none, no gate to enforce.
+batch=$(jq -r '.batches[]? | select(.status=="in_progress") | .batch' "$progress" 2>/dev/null | head -1)
+if [[ -z "$batch" ]]; then
+    exit 0
+fi
+
+pad=$(printf '%02d' "$batch")
+stamp="runs/matrix-sampled/batch-${pad}/.preflight-confirmed"
+
+if [[ -f "$stamp" ]]; then
+    exit 0
+fi
+
+# No stamp → block. Stderr message tells the orchestrator what to do.
+cat >&2 <<EOF
+BLOCKED by .claude/hooks/preflight_gate.sh:
+  batch ${batch} is in_progress but has no preflight stamp at ${stamp}.
+
+To proceed:
+  1. Surface the cost preflight (Phase 2.5) to the user.
+  2. Get an explicit OK on this specific batch.
+  3. Run: touch ${stamp}
+  4. Retry the Agent call.
+
+To bypass (non-smoke-test Agent work mid-batch):
+  - Complete or pause the batch: jq '.batches[] |= (if .status=="in_progress" then .status="paused" else . end)' ${progress} > /tmp/p.json && mv /tmp/p.json ${progress}
+  - Or delete the stamp file when done: rm ${stamp}
+
+This hook exists because CLAUDE.md mandates per-batch cost-preflight
+confirmation, and prior runs (batch-2 in this repo) showed the orchestrator
+can mentally skip the gate. The hook physically prevents that.
+EOF
+exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/preflight_gate.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(npx tsc --noEmit *)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx tsc --noEmit *)",
+      "Bash(npm run lint *)",
+      "mcp__vaultpilot-mcp__get_transaction_history",
+      "mcp__vaultpilot-mcp__preview_send",
+      "mcp__vaultpilot-mcp__prepare_token_send",
+      "mcp__vaultpilot-mcp__get_transaction_status",
+      "mcp__vaultpilot-mcp__prepare_custom_call",
+
+      "Bash(python3 tools/sample_matrix_run.py *)",
+      "Bash(python3 tools/file_batch_issues.py --batch * --repo szhygulin/vaultpilot-mcp *)",
+      "Bash(python3 tools/file_batch_issues.py --batch * --repo szhygulin/vaultpilot-mcp)",
+      "Bash(python3 test-vectors/build_*matrix.py)",
+      "Bash(python3 test-vectors/build_matrix.py)",
+      "Bash(touch runs/matrix-sampled/batch-*/.preflight-confirmed)",
+      "Bash(tools/post_batch_commit.sh *)",
+      "Bash(./tools/post_batch_commit.sh *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.tmp
 __pycache__/
 node_modules/
-.claude/
+# .claude/ is project methodology (settings.json, commands/, hooks/) — track it.
+# Only the per-developer local-overrides file is ignored.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,21 @@ When the `mcp-smoke-test` skill is loaded (it lives at `skill/SKILL.md` in this 
 - **Don't skip steps** in the 6-phase pipeline (Catalog → Generate → Cost preflight → Spawn → Concat → Analyze → File). Phases 1, 4, 6 are mode-independent; Phases 2, 3, 5 branch by mode (honest vs. adversarial). Cost preflight (2.5) is mandatory in both modes.
 - **A.5 / C.5 findings never go in `issues.draft.json`.** They route to the §7 upstream-escalation note (chat-client output filter for injection-shaped, model-layer safety for model-shaped). Filing them as MCP/skill defects produces security theater per issue #21.
 - If a skill instruction conflicts with what looks faster or simpler, the skill wins. Surface the conflict to the user before deviating.
+
+## Preflight gate (PreToolUse hook on `Agent`)
+
+The Phase 2.5 cost-preflight rule above is enforced by a **PreToolUse hook** at `.claude/hooks/preflight_gate.sh`, registered in `.claude/settings.json`. The hook physically blocks `Agent` tool calls during a smoke-test batch unless the batch's `.preflight-confirmed` stamp file exists.
+
+Flow:
+
+1. `python3 tools/sample_matrix_run.py next-batch` writes `runs/matrix-sampled/batch-NN/scripts.json` and marks the batch `in_progress` in `progress.json`.
+2. The orchestrator surfaces the cost preflight block to the user (sample, role distribution, A.5/C.5 share, E control share, Haiku throughput, Opus analysis cost, wall-clock estimate, filing target).
+3. **User says "go" / "OK"** explicitly for THIS batch.
+4. The orchestrator runs `touch runs/matrix-sampled/batch-NN/.preflight-confirmed`. This `touch` is the only place the stamp is created and is pre-approved in `.claude/settings.json`.
+5. Subsequent `Agent` calls pass the hook (stamp present).
+
+If the orchestrator forgets step 2-3 and tries to dispatch directly, the hook exits 1 with a stderr message naming the missing stamp. The orchestrator must then go back to step 2.
+
+**Bypass for non-smoke-test work mid-batch**: if you need an `Agent` call unrelated to the batch while a batch is in_progress (rare in this single-purpose repo), either complete/pause the batch first, or delete the stamp + reset the in_progress entry temporarily. Documented in the hook script's stderr output.
+
+**Why this hook exists**: prior session (batch-2 in this repo) showed the orchestrator can mentally skip the cost-preflight rule even when CLAUDE.md says "mandatory". The hook makes the gate physical, not advisory.

--- a/tools/post_batch_commit.sh
+++ b/tools/post_batch_commit.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# tools/post_batch_commit.sh — auto-commit + push + PR for a completed smoke-test batch.
+#
+# Usage: tools/post_batch_commit.sh <batch_number>
+#
+# Effects:
+#   1. Creates branch `batch-<NN>-results` (NN zero-padded; never main per CLAUDE.md).
+#   2. Stages and commits runs/matrix-sampled/batch-<NN>/ + progress.json.
+#   3. Pushes the branch with -u to set upstream.
+#   4. Opens a PR with title + body templated from aggregate.json + findings.md.
+#
+# This script is idempotent in the sense that re-running on the same batch
+# (already committed) will fail at `git checkout -b` and the user can resolve
+# manually. We DO NOT force-push or amend — every batch gets its own branch.
+#
+# Exits non-zero on any error (set -e). Caller (the /run-batch slash command)
+# surfaces failures to the user.
+
+set -euo pipefail
+
+batch="${1:-}"
+if [[ -z "$batch" ]]; then
+    echo "Usage: $0 <batch_number>" >&2
+    exit 1
+fi
+pad=$(printf '%02d' "$batch")
+batch_dir="runs/matrix-sampled/batch-${pad}"
+
+if [[ ! -d "$batch_dir" ]]; then
+    echo "ERROR: $batch_dir does not exist." >&2
+    exit 1
+fi
+if [[ ! -f "$batch_dir/aggregate.json" ]]; then
+    echo "ERROR: $batch_dir/aggregate.json missing — has Phase 4 mark-completed run?" >&2
+    exit 1
+fi
+if [[ ! -f "$batch_dir/findings.md" ]]; then
+    echo "ERROR: $batch_dir/findings.md missing — has Phase 5 analyst run?" >&2
+    exit 1
+fi
+if [[ ! -f "$batch_dir/issues.md" ]]; then
+    echo "ERROR: $batch_dir/issues.md missing — has Phase 6 filer run?" >&2
+    exit 1
+fi
+
+# Extract headline numbers for the commit message + PR title.
+total=$(jq -r '.total_transcripts' "$batch_dir/aggregate.json")
+tricked=$(jq -r '.tricked_count' "$batch_dir/aggregate.json")
+filed=$(grep -c '^| [0-9]' "$batch_dir/issues.md" || echo 0)
+roles=$(jq -r '.by_role | to_entries | map("\(.key): \(.value)") | join(", ")' "$batch_dir/aggregate.json")
+
+branch="batch-${pad}-results"
+if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+    echo "ERROR: branch $branch already exists. Resolve manually." >&2
+    exit 1
+fi
+
+git checkout -b "$branch"
+git add "$batch_dir/" runs/matrix-sampled/progress.json
+
+git commit -m "$(cat <<EOF
+batch-${batch} results: ${total} cells, ${tricked} user-tricked, ${filed} issues filed
+
+Roles: ${roles}
+
+Artifacts:
+- ${batch_dir}/scripts.json — dispatched cells
+- ${batch_dir}/transcripts/ — per-cell reports
+- ${batch_dir}/summary.txt — structured summary
+- ${batch_dir}/aggregate.json — counters
+- ${batch_dir}/findings.md — Phase 5 markdown analysis
+- ${batch_dir}/issues.draft.json — drafted issues
+- ${batch_dir}/issues.md — filing log with URLs
+EOF
+)"
+
+git push -u origin "$branch"
+
+# PR body: paste findings.md (it's the canonical analysis already).
+gh pr create \
+    --title "batch-${batch} results: ${total} cells, ${tricked} tricked, ${filed} issues filed" \
+    --body-file "$batch_dir/findings.md"
+
+echo "post_batch_commit.sh complete: branch=$branch"


### PR DESCRIPTION
## Summary

PR 2 of 4. Stacks on PR #30 (Lane 4 /run-batch). Makes the Phase 2.5 cost-preflight rule physical via a PreToolUse hook on `Agent` calls.

## Why

CLAUDE.md mandates per-batch cost-preflight confirmation. In the prior session I dispatched batch-2 without surfacing the preflight — the rule was advisory, the orchestrator skipped it. This PR adds a hook that exits 1 if a batch is `in_progress` and the `.preflight-confirmed` stamp is missing.

## What ships

- **`.claude/hooks/preflight_gate.sh`** — `set -euo pipefail`. Reads `progress.json`; if no batch `in_progress`, exits 0 (passthrough for non-smoke-test work). If stamp exists, exits 0. Otherwise exits 1 with a structured stderr message naming the missing stamp + recovery instructions (normal flow + bypass for non-smoke-test).
- **`.claude/settings.json`** — adds `hooks.PreToolUse` matcher on `Agent`.
- **CLAUDE.md** — new section *Preflight gate (PreToolUse hook on Agent)* documenting the 5-step integration with `/run-batch` and the bypass procedure.

## Integration with Lane 4

`/run-batch` step 3 is `touch runs/matrix-sampled/batch-NN/.preflight-confirmed`. That `touch` is the only place the stamp is created and is pre-approved in `.claude/settings.json` (added in Lane 4). The hook checks for that stamp.

If Lane 4 hasn't merged yet (this PR is stacked on top), the hook still works — it just blocks every `Agent` call until the user walks through preflight manually + stamps.

## Verification

Synthesised fake `progress.json` with batch 99 in_progress and tested the hook directly:
- No stamp → exits 1, stderr message renders cleanly with all recovery instructions.
- Stamp touched → exits 0 silently.

## Trade-off

The hook fires on EVERY `Agent` call when a batch is in_progress. That includes non-smoke-test agents (Explore, Plan, etc.) if you happen to invoke one mid-batch. Bypass procedure documented in the hook stderr + CLAUDE.md: complete/pause the batch first, or temporarily flip status in `progress.json` to `paused`.

For this single-purpose repo, "loud and fail-safe" beats "smart and leaky".

🤖 Generated with [Claude Code](https://claude.com/claude-code)