### PR TITLE
CLAUDE.md: test workdir stays inside this repo (don't create folders outside)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,19 @@ When asked to "commit and push", interpret that as:
 
 If you're already sitting on `main` with local commits when this comes up, move them to a new branch before pushing — do not push `main` directly. Reset `main` to `origin/main` only after the new branch is in place and pushed.
 
+## Test workdir stays inside this repo
+
+When running a smoke-test batch, **all artifacts (`scripts.json`, `transcripts/`, `summary.txt`, `aggregate.json`, `findings.md`, `issues.draft.json`, `issues.md`) live under `runs/matrix-sampled/batch-NN/` inside this repository.** Do NOT create a workdir outside the repo (e.g. `~/dev/<target-mcp>-smoke-test/`) like the older `README.md` §3 walkthrough showed; that pattern was for a portable methodology installed across multiple repos, but this repo is single-purpose and the methodology + artifacts are versioned together here.
+
+Concretely:
+
+- `tools/sample_matrix_run.py next-batch` always writes to `runs/matrix-sampled/batch-NN/`. Don't override the path.
+- `/run-batch` slash command and `tools/post_batch_commit.sh` both assume in-repo paths.
+- The Lane 3 PreToolUse hook reads `runs/matrix-sampled/progress.json` (relative path); a workdir outside the repo would silently bypass it.
+- Committed artifacts (per batch) ship in this same repo as a feature branch + PR (`tools/post_batch_commit.sh` does that automatically).
+
+If you need a one-off / non-batch test that for some reason can't live under `runs/matrix-sampled/`, surface the reason to the user before creating any path outside the repo. The default is always: **stay inside this folder.**
+
 ## mcp-smoke-test methodology is binding
 
 The full methodology lives in this CLAUDE.md (see *Smoke-test methodology* section below — moved here from `skill/SKILL.md` in Lane 2 to eliminate skill-loading fragility). Every instruction in it is **mandatory**, not advisory. In particular:

--- a/README.md
+++ b/README.md
@@ -43,22 +43,25 @@ Three catalogs ship in [`test-vectors/`](test-vectors/), each tested in producti
 
 Or generate your own — see `CLAUDE.md (Smoke-test methodology section)` Phase 2 for catalog targets.
 
-### 3. Set up a workdir
+### 3. Workdir is in-repo (don't create folders outside)
 
-```bash
-mkdir -p ~/dev/<your-target-mcp>-smoke-test/transcripts
-cd ~/dev/<your-target-mcp>-smoke-test
-cp <this-repo>/test-vectors/<your-vector>.json scripts.json
-```
-
-The skill expects this layout:
+All test artifacts live under `runs/matrix-sampled/batch-NN/` inside this repository — see CLAUDE.md *Test workdir stays inside this repo* rule. The `/run-batch` slash command and `tools/sample_matrix_run.py` create + populate that directory automatically; you don't need to set up a workdir manually.
 
 ```
-<workdir>/
-├── scripts.json
-├── transcripts/      ← subagent transcripts written here
-└── (later) all_transcripts.txt, summary.txt, findings.md
+runs/matrix-sampled/
+├── partition.json                    # the deterministic 181-batch plan (seed 42)
+├── progress.json                     # which batches are pending / in_progress / completed
+└── batch-NN/
+    ├── scripts.json                  # the 50 cells dispatched in this batch
+    ├── transcripts/{cell-id}.txt     # per-cell subagent reports
+    ├── summary.txt                   # structured per-script summary
+    ├── aggregate.json                # role / defense / tricked counters + parse_failures
+    ├── findings.md                   # Phase 5 markdown analysis
+    ├── issues.draft.json             # 5-8 fileable issues
+    └── issues.md                     # filing log with #NNN URLs
 ```
+
+(Earlier README walkthroughs pointed at `~/dev/<target-mcp>-smoke-test/` as the workdir — that pattern was for a portable methodology installed across multiple repos. Lane 2 of the 4-lane overhaul moved the methodology into CLAUDE.md, so workdir + methodology + artifacts are all versioned together in this single repo.)
 
 ### 4. Trigger the skill
 


### PR DESCRIPTION
## Summary

Adds an explicit project rule that batch artifacts live under `runs/matrix-sampled/batch-NN/` inside this repo, not in an external workdir like `~/dev/<target-mcp>-smoke-test/`. The older README §3 walkthrough showed an external pattern; that's left over from when the methodology was portable across repos. Lane 2 (PR #34) made this repo single-purpose, so external workdirs no longer make sense.

Why this matters concretely:

- The Lane 3 PreToolUse hook reads `runs/matrix-sampled/progress.json` (relative path); an out-of-repo workdir silently bypasses it.
- `/run-batch` slash command and `tools/post_batch_commit.sh` both assume in-repo paths.
- Committed artifacts ship as feature branches in *this* repo.

## What changes

- **`CLAUDE.md`**: new section *Test workdir stays inside this repo* in the project rules block (between Git workflow and the binding-rules). Spells out the rule, hook consequence, and the surface-the-reason exception path.
- **`README.md` §3**: rewrote "Set up a workdir" → "Workdir is in-repo (don't create folders outside)". Replaced the manual `mkdir -p ~/dev/...` recipe with a description of the auto-populated `runs/matrix-sampled/` layout.

## Stacking

Stacks on PR #34 (Lane 2) since both touch CLAUDE.md and README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)