### PR TITLE
ci: run mock test suite on PR and push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Mock test suite (Python ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Verify required tools
+        run: |
+          python3 --version
+          jq --version
+
+      - name: Run mock test suite
+        run: ./tests/run-all.sh
+
+      - name: Upload per-suite logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-py${{ matrix.python }}
+          path: tests/.last-run/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` mirroring vaultpilot-mcp's ci.yml shape (push/pull_request triggers, concurrency cancellation, version matrix).
- Adapts for this repo's bash + Python tooling: runs `./tests/run-all.sh` on Python 3.11 and 3.12 (jq is preinstalled on ubuntu-latest).
- Uploads `tests/.last-run/` per-suite logs as artifacts on failure.

Local run before push: 206 passed, 0 failed.

## Test plan
- [ ] CI green on this PR (both Python 3.11 and 3.12 jobs pass)
- [ ] If failure: confirm the `test-logs-py*` artifact uploads and contains the per-suite logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)