### PR TITLE
Three-layer no-broadcast defense (demo mode + permissions.deny + PreToolUse hook)

### DIFF
--- a/.claude/hooks/no_broadcast_gate.sh
+++ b/.claude/hooks/no_broadcast_gate.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# .claude/hooks/no_broadcast_gate.sh — PreToolUse hook for the mutating
+# vaultpilot-mcp tool surface (Layer 3 of the no-broadcast defense).
+#
+# Smoke-test runs MUST never broadcast on-chain or persist mutating local
+# state on the operator's box. This hook is the third independent layer
+# enforcing that rule:
+#
+#   Layer 1: MCP demo mode (VAULTPILOT_DEMO=true + set_demo_wallet)
+#   Layer 2: permissions.deny in .claude/settings.json
+#   Layer 3: this PreToolUse hook (regex matcher in settings.json)
+#
+# All three layers are load-bearing. Weakening any one is a security
+# regression — see the "No-broadcast hard gate" section in CLAUDE.md.
+#
+# This hook always exits 1 (blocking) when invoked. The matcher in
+# .claude/settings.json is the source of truth for which tools trigger
+# this hook; the script's job is to refuse + surface a clear message
+# so the operator can diagnose how Layers 1+2 were bypassed.
+#
+# Why a hook in addition to permissions.deny:
+#   - Defense in depth against compound-command bypass shapes the SDK
+#     gate may not anticipate.
+#   - Surfaces a structured diagnostic when reached, vs. permissions.deny
+#     which silently auto-denies.
+#   - Survives accidental allow-list regressions that shadow the deny.
+#
+# Inputs: PreToolUse hooks may receive a JSON payload on stdin describing
+# the tool call. The script reads it best-effort to surface the tool name
+# in the diagnostic; the matcher in settings.json is the actual gate.
+#
+# Exit codes:
+#   1 — always (this hook only runs for tools that should be blocked).
+
+set -uo pipefail
+
+# Best-effort: read stdin payload and extract tool_name for diagnostics.
+# Older Claude Code versions may not pipe anything; jq may be absent.
+payload=""
+if [[ ! -t 0 ]]; then
+    payload=$(cat 2>/dev/null || true)
+fi
+tool_name=""
+if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+    tool_name=$(echo "$payload" | jq -r '.tool_name // empty' 2>/dev/null || true)
+fi
+
+cat >&2 <<EOF
+BLOCKED by .claude/hooks/no_broadcast_gate.sh:
+  tool ${tool_name:-<mutating vaultpilot-mcp tool>} is on the no-broadcast deny list.
+
+Smoke-test runs MUST never broadcast on-chain or persist mutating local
+state. The mutating tool surface (send_transaction, submit_*, sign_*,
+finalize_*, import_*, share_*, generate_readonly_link) is blocked by
+three independent layers:
+  1. MCP demo mode (VAULTPILOT_DEMO=true + set_demo_wallet)
+  2. permissions.deny in .claude/settings.json
+  3. This PreToolUse hook (belt-and-suspenders)
+
+If you reached this hook, Layers 1+2 either failed to engage or were
+bypassed by a compound-command shape. Halt the run and inspect:
+  - VAULTPILOT_DEMO env var on the vaultpilot-mcp server
+  - get_demo_wallet probe returns active demo persona
+  - .claude/settings.json deny list still names this tool
+  - No stray allow entry shadows the deny
+
+To intentionally weaken (e.g. testing the gate itself): document the
+weakening in the PR description per CLAUDE.md "No-broadcast hard gate".
+EOF
+exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": ".claude/hooks/preflight_gate.sh"
           }
         ]
+      },
+      {
+        "matcher": "mcp__vaultpilot-mcp__(send_transaction|submit_safe_tx_signature|sign_btc_multisig_psbt|sign_message_btc|sign_message_ltc|finalize_btc_psbt|import_strategy|share_strategy|import_readonly_token|generate_readonly_link)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/no_broadcast_gate.sh"
+          }
+        ]
       }
     ]
   },
@@ -55,6 +64,18 @@
       "Bash(git status *)",
       "Bash(git diff *)",
       "Bash(git branch *)"
+    ],
+    "deny": [
+      "mcp__vaultpilot-mcp__send_transaction",
+      "mcp__vaultpilot-mcp__submit_safe_tx_signature",
+      "mcp__vaultpilot-mcp__sign_btc_multisig_psbt",
+      "mcp__vaultpilot-mcp__sign_message_btc",
+      "mcp__vaultpilot-mcp__sign_message_ltc",
+      "mcp__vaultpilot-mcp__finalize_btc_psbt",
+      "mcp__vaultpilot-mcp__import_strategy",
+      "mcp__vaultpilot-mcp__share_strategy",
+      "mcp__vaultpilot-mcp__import_readonly_token",
+      "mcp__vaultpilot-mcp__generate_readonly_link"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,18 @@ This is separate from per-cell findings — those go through `issues.draft.json`
 
 For non-batch `Agent` work mid-batch: complete/pause the batch first, or temporarily delete the stamp + reset the in_progress entry.
 
+## No-broadcast hard gate (three layers, all load-bearing)
+
+Smoke-test runs MUST never broadcast on-chain or persist mutating local state. Three independent layers enforce this; weakening any one is a security regression and must be called out in the PR description.
+
+1. **MCP demo mode.** `VAULTPILOT_DEMO=true` env var on the vaultpilot-mcp server + `set_demo_wallet` activating a demo persona. Auto-enabled by the orchestrator per the "Auto-enable demo mode when supported" section below.
+2. **`permissions.deny`** in `.claude/settings.json`. Explicit deny entries for the mutating tool surface — `send_transaction`, `submit_safe_tx_signature`, `sign_btc_multisig_psbt`, `sign_message_btc`, `sign_message_ltc`, `finalize_btc_psbt`, `import_strategy`, `share_strategy`, `import_readonly_token`, `generate_readonly_link`. The `prepare_*` family stays allowed — those are the test surface.
+3. **PreToolUse hook** `.claude/hooks/no_broadcast_gate.sh` registered with a regex matcher covering the same tool list. Belt-and-suspenders against compound-command bypass shapes the SDK gate may not anticipate, and against accidental allow-list regressions that shadow the deny.
+
+Adding a new mutating tool to vaultpilot-mcp requires updating BOTH the deny list AND the hook matcher in `.claude/settings.json`. Tests in `tests/suites/45-no-broadcast-hook.sh` enforce coverage parity between the two.
+
+The dispatch prompt in `tools/build_dispatch_prompt.py` ALSO tells subagents not to broadcast — that's a soft constraint relying on subagent compliance. Layers 1–3 above are hard enforcement.
+
 ## Subagent dispatch transcript format
 
 Each per-cell subagent emits this strict format. Required fields enforce no-silent-skips:
@@ -251,7 +263,7 @@ Dispatch in **background batches** via `Agent` with `run_in_background: true`, `
 
 Subagents must emit canonical tokens directly. Free-form commentary belongs in `notes`.
 
-**No-broadcast / no-write rule.** Smoke-test value is in *what the MCP would do* via prepare/preview/dry-run. If the MCP has no dry-run, that's a finding.
+**No-broadcast / no-write rule.** Smoke-test value is in *what the MCP would do* via prepare/preview/dry-run. If the MCP has no dry-run, that's a finding. Hard enforcement lives in three independent layers — see "No-broadcast hard gate" in the project rules above.
 
 **Don't retry denied tools.** Note harness denials once as meta-finding; don't generate per-script bug reports.
 

--- a/tests/suites/45-no-broadcast-hook.sh
+++ b/tests/suites/45-no-broadcast-hook.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# 45-no-broadcast-hook.sh — exercises .claude/hooks/no_broadcast_gate.sh
+# and the deny/matcher coverage in .claude/settings.json.
+# Verifies:
+#   - Hook script exists and is executable
+#   - Hook always exits 1 (blocking), regardless of stdin payload shape
+#   - Stderr message includes "BLOCKED" + diagnostic context
+#   - settings.json permissions.deny covers all expected mutating tools
+#   - settings.json registers the hook with a matcher covering the same set
+#   - prepare_* family remains in the allow surface (NOT denied)
+#   - deny list and hook matcher cover the SAME tool set (parity check)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/helpers.sh"
+
+echo ""
+echo "=== Suite 45: no-broadcast hook ==="
+
+HOOK="$REPO_ROOT/.claude/hooks/no_broadcast_gate.sh"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+assert_file_exists "$HOOK" "hook script exists"
+assert_file_exists "$SETTINGS" "settings.json exists"
+
+if [[ -x "$HOOK" ]]; then
+    _test_pass "hook script is executable"
+else
+    _test_fail "hook script is not executable"
+fi
+
+# The canonical mutating tool surface — keep aligned with the issue body
+# and with the deny + matcher in .claude/settings.json.
+EXPECTED_DENIED=(
+    "mcp__vaultpilot-mcp__send_transaction"
+    "mcp__vaultpilot-mcp__submit_safe_tx_signature"
+    "mcp__vaultpilot-mcp__sign_btc_multisig_psbt"
+    "mcp__vaultpilot-mcp__sign_message_btc"
+    "mcp__vaultpilot-mcp__sign_message_ltc"
+    "mcp__vaultpilot-mcp__finalize_btc_psbt"
+    "mcp__vaultpilot-mcp__import_strategy"
+    "mcp__vaultpilot-mcp__share_strategy"
+    "mcp__vaultpilot-mcp__import_readonly_token"
+    "mcp__vaultpilot-mcp__generate_readonly_link"
+)
+
+# Test 1: hook exits 1 with a JSON payload naming a denied tool
+set +e
+STDERR=$(echo '{"tool_name":"mcp__vaultpilot-mcp__send_transaction"}' | "$HOOK" 2>&1 >/dev/null)
+EC=$?
+set -e
+assert_exit_code 1 "$EC" "hook exits 1 (blocking) with a denied tool payload"
+assert_contains "$STDERR" "BLOCKED" "stderr starts with BLOCKED"
+assert_contains "$STDERR" "no-broadcast deny list" "stderr names the deny list"
+assert_contains "$STDERR" "send_transaction" "stderr surfaces tool_name from payload"
+
+# Test 2: hook exits 1 with empty stdin (older Claude Code versions / test contexts)
+set +e
+STDERR=$(: | "$HOOK" 2>&1 >/dev/null)
+EC=$?
+set -e
+assert_exit_code 1 "$EC" "hook exits 1 with empty stdin"
+assert_contains "$STDERR" "BLOCKED" "stderr still BLOCKED with empty stdin"
+
+# Test 3: hook exits 1 with malformed JSON payload (jq failure shouldn't crash)
+set +e
+STDERR=$(echo 'not json at all' | "$HOOK" 2>&1 >/dev/null)
+EC=$?
+set -e
+assert_exit_code 1 "$EC" "hook exits 1 with malformed JSON payload"
+assert_contains "$STDERR" "BLOCKED" "stderr still BLOCKED with malformed JSON"
+
+# Test 4: stderr names all three layers so the operator can diagnose bypass
+assert_contains "$STDERR" "MCP demo mode" "stderr names Layer 1 (demo mode)"
+assert_contains "$STDERR" "permissions.deny" "stderr names Layer 2 (deny list)"
+assert_contains "$STDERR" "PreToolUse hook" "stderr names Layer 3 (this hook)"
+
+# Test 5: settings.json deny list covers every expected mutating tool
+for tool in "${EXPECTED_DENIED[@]}"; do
+    if jq -e --arg t "$tool" '.permissions.deny | index($t)' "$SETTINGS" >/dev/null 2>&1; then
+        _test_pass "deny list contains $tool"
+    else
+        _test_fail "deny list missing $tool"
+    fi
+done
+
+# Test 6: hook is registered as a PreToolUse entry pointing at no_broadcast_gate.sh
+HOOK_MATCHER=$(jq -r '
+    .hooks.PreToolUse[]?
+    | select(.hooks[]?.command == ".claude/hooks/no_broadcast_gate.sh")
+    | .matcher
+' "$SETTINGS" 2>/dev/null || echo "")
+if [[ -n "$HOOK_MATCHER" ]]; then
+    _test_pass "no_broadcast_gate.sh registered as PreToolUse hook"
+else
+    _test_fail "no_broadcast_gate.sh not registered in settings.json hooks"
+fi
+
+# Test 7: hook matcher (treated as regex) covers every expected denied tool
+if [[ -n "$HOOK_MATCHER" ]]; then
+    for tool in "${EXPECTED_DENIED[@]}"; do
+        if echo "$tool" | grep -qE "$HOOK_MATCHER"; then
+            _test_pass "matcher regex covers $tool"
+        else
+            _test_fail "matcher regex does not cover $tool (matcher: $HOOK_MATCHER)"
+        fi
+    done
+fi
+
+# Test 8: prepare_* family is NOT in deny list (those are the test surface)
+PREPARE_TOOLS=(
+    "mcp__vaultpilot-mcp__prepare_token_send"
+    "mcp__vaultpilot-mcp__prepare_custom_call"
+)
+for tool in "${PREPARE_TOOLS[@]}"; do
+    if jq -e --arg t "$tool" '.permissions.deny | index($t)' "$SETTINGS" >/dev/null 2>&1; then
+        _test_fail "prepare-family tool $tool unexpectedly in deny list (test surface must remain allowed)"
+    else
+        _test_pass "$tool correctly NOT in deny list"
+    fi
+done
+
+# Test 9: matcher does NOT match prepare_* tools (no over-matching)
+if [[ -n "$HOOK_MATCHER" ]]; then
+    for tool in "${PREPARE_TOOLS[@]}"; do
+        if echo "$tool" | grep -qE "$HOOK_MATCHER"; then
+            _test_fail "matcher regex over-matches $tool (test surface must not fire the gate)"
+        else
+            _test_pass "matcher correctly does NOT match $tool"
+        fi
+    done
+fi
+
+# Test 10: existing preflight hook on Agent still wired up (no regression)
+PREFLIGHT_PRESENT=$(jq -r '
+    .hooks.PreToolUse[]?
+    | select(.matcher == "Agent" and (.hooks[]?.command == ".claude/hooks/preflight_gate.sh"))
+    | .matcher
+' "$SETTINGS" 2>/dev/null || echo "")
+if [[ "$PREFLIGHT_PRESENT" == "Agent" ]]; then
+    _test_pass "Agent → preflight_gate.sh hook still registered"
+else
+    _test_fail "Agent → preflight_gate.sh hook missing (regression)"
+fi
+
+cd "$REPO_ROOT"
+echo ""


### PR DESCRIPTION
Closes #56.

## Summary

The no-broadcast rule was enforced by exactly one layer (MCP demo mode). If demo mode silently disengaged, was never activated, or got bypassed by a compromised MCP, an `mcp__vaultpilot-mcp__send_transaction` from a per-cell subagent could reach the chain. This PR adds two harness-side layers, mirroring vp-dev's three-layer push protection.

## Layers (all load-bearing)

1. **MCP demo mode** (existing) — `VAULTPILOT_DEMO=true` + `set_demo_wallet`.
2. **`permissions.deny`** in `.claude/settings.json` — explicit deny entries for `send_transaction`, `submit_safe_tx_signature`, `sign_btc_multisig_psbt`, `sign_message_btc`, `sign_message_ltc`, `finalize_btc_psbt`, `import_strategy`, `share_strategy`, `import_readonly_token`, `generate_readonly_link`. The `prepare_*` family stays allowed — that's the test surface.
3. **PreToolUse hook** `.claude/hooks/no_broadcast_gate.sh` registered with a regex matcher covering the same tool list. Always exits 1 with a diagnostic naming all three layers so the operator can trace which earlier layer was bypassed.

## Tests

`tests/suites/45-no-broadcast-hook.sh` (10 assertion blocks) verifies:
- Hook script exists, is executable, exits 1 with various stdin payload shapes (well-formed JSON, empty, malformed) and surfaces "BLOCKED" + the three-layer description.
- `permissions.deny` covers every expected mutating tool.
- The PreToolUse matcher (treated as regex) covers the same set — coverage parity is enforced so adding a new mutating tool requires updating both.
- The `prepare_*` family is NOT in the deny list and is NOT matched by the hook regex (no over-matching of the test surface).
- Existing `Agent → preflight_gate.sh` wiring is intact (no regression).

I could not invoke `tests/run-all.sh` from inside the dispatch sandbox (the runner isn't on this agent's gate allowlist; this repo has no `npm test` / `package.json` either). Validated instead via `jq` structural checks on the new `settings.json` (10 deny entries, 2 PreToolUse hooks, valid JSON) and by reading the bash carefully alongside the parallel `40-preflight-hook.sh` suite. Please run `./tests/run-all.sh` locally to confirm.

## Documentation

- New CLAUDE.md section "No-broadcast hard gate (three layers, all load-bearing)" alongside the existing Preflight gate section, documenting the three-layer model + the deny-list/matcher parity rule.
- The in-Phase-3 "No-broadcast / no-write rule" callout cross-references it.

The dispatch prompt in `tools/build_dispatch_prompt.py` already tells subagents not to broadcast — that's a soft constraint relying on subagent compliance. Layers 1–3 are hard enforcement.

## Test plan

- [ ] `./tests/run-all.sh` passes (suite 45 plus existing 10 suites).
- [ ] During the next batch run, attempting to call any of the 10 deny-listed tools from a subagent surfaces a `BLOCKED by .claude/hooks/no_broadcast_gate.sh` line in stderr (visible to the orchestrator).
- [ ] `mcp__vaultpilot-mcp__prepare_token_send` and `mcp__vaultpilot-mcp__prepare_custom_call` continue to work — these are the test surface and must not be blocked.

— Fibonacci (agent-41bd)
