### PR TITLE
surface-taxonomy: drop A.5 / C.5 advisory-prose roles from the matrix

### DIFF
--- a/tests/suites/100-surface-taxonomy.sh
+++ b/tests/suites/100-surface-taxonomy.sh
@@ -34,12 +34,22 @@ assert_equals "yes" "$(_check tax_regulatory C.1)" "tax_regulatory excludes C.1 
 assert_equals "yes" "$(_check tax_regulatory D)"   "tax_regulatory excludes D (skill-tamper)"
 assert_equals "yes" "$(_check tax_regulatory F)"   "tax_regulatory excludes F (rogue RPC)"
 
-# Test 2: surface-agnostic roles always kept
+# Test 2: surface-agnostic roles always kept (A.4, C.4, E)
+# A.5 / C.5 are explicitly excluded everywhere — see ROGUE_AGENT_ADVISORY_ROLES
+# in surface_taxonomy.py. Their findings always bulk-close as architectural
+# at the MCP repo (canonical: vaultpilot-mcp#536); excluding them at
+# generation time saves Haiku throughput + Phase-5 Opus context.
 assert_equals "no" "$(_check tax_regulatory A.4)"  "tax_regulatory keeps A.4 (planted context)"
-assert_equals "no" "$(_check tax_regulatory A.5)"  "tax_regulatory keeps A.5 (advisory)"
 assert_equals "no" "$(_check tax_regulatory C.4)"  "tax_regulatory keeps C.4 (collude context)"
-assert_equals "no" "$(_check tax_regulatory C.5)"  "tax_regulatory keeps C.5 (collude advisory)"
 assert_equals "no" "$(_check tax_regulatory E)"    "tax_regulatory keeps E (control)"
+
+# Test 2b: A.5 / C.5 (rogue-agent advisory) excluded everywhere
+assert_equals "yes" "$(_check tax_regulatory A.5)"     "tax_regulatory excludes A.5 (rogue-agent advisory)"
+assert_equals "yes" "$(_check tax_regulatory C.5)"     "tax_regulatory excludes C.5 (rogue-agent advisory)"
+assert_equals "yes" "$(_check send_native A.5)"        "send_native excludes A.5 (rogue-agent advisory)"
+assert_equals "yes" "$(_check send_native C.5)"        "send_native excludes C.5 (rogue-agent advisory)"
+assert_equals "yes" "$(_check edge_unsupported A.5)"   "edge_unsupported excludes A.5 (rogue-agent advisory)"
+assert_equals "yes" "$(_check brand_new_category A.5)" "unknown category excludes A.5 (rogue-agent advisory)"
 
 # Test 3: unknown category defaults to {signing, read} (kept by default)
 assert_equals "no" "$(_check brand_new_category A.1)" "unknown category keeps A.1 (default conservative)"
@@ -50,9 +60,12 @@ assert_equals "no" "$(_check brand_new_category F)"   "unknown category keeps F 
 assert_equals "no" "$(_check send_native A.1)" "send_native keeps A.1"
 assert_equals "no" "$(_check swap_cross D)"    "swap_cross keeps D"
 
-# Test 5: edge_unsupported special-case (only B + advisory roles kept)
+# Test 5: edge_unsupported special-case (only B + non-advisory surface-agnostic roles kept)
+# A.5 / C.5 are now globally excluded (Test 2b); edge_unsupported still keeps B
+# (the cell's purpose is "MCP spoofs success on unsupported chain") and the
+# remaining surface-agnostic roles (A.4, C.4, E).
 assert_equals "no"  "$(_check edge_unsupported B)"   "edge_unsupported keeps B (b-special)"
-assert_equals "no"  "$(_check edge_unsupported A.5)" "edge_unsupported keeps A.5 (advisory)"
+assert_equals "no"  "$(_check edge_unsupported A.4)" "edge_unsupported keeps A.4 (planted context)"
 assert_equals "no"  "$(_check edge_unsupported E)"   "edge_unsupported keeps E (control)"
 assert_equals "yes" "$(_check edge_unsupported A.1)" "edge_unsupported excludes A.1"
 assert_equals "yes" "$(_check edge_unsupported D)"   "edge_unsupported excludes D"

--- a/tools/surface_taxonomy.py
+++ b/tools/surface_taxonomy.py
@@ -67,13 +67,45 @@ ROLE_REQUIRED_SURFACES = {
 }
 
 
+# Roles whose harmful payload is agent-generated prose with no MCP/skill
+# trust boundary. Findings from these roles consistently bulk-close as
+# architectural / Rogue-Agent-Only at the MCP repo (canonical closure:
+# vaultpilot-mcp#536; recent batch closures #595/#596/#597/#598/#583/#584/
+# #585/#586 + earlier #540/#541/#543/#544). Defense lives at the chat-client
+# output filter (A.5a / C.5a injection-shaped) or Anthropic model-layer
+# safety (A.5b / C.5b model-shaped) — neither in scope for this MCP.
+#
+# Methodology already routes A.5 / C.5 findings to §7 upstream-escalation
+# rather than MCP/skill issue filing (see CLAUDE.md Role-A library and
+# vaultpilot-mcp-smoke-test#52). This filter complements that on the
+# generation side: skip dispatching cells whose findings we already know
+# we'll route upstream, saving Haiku throughput, Phase-5 Opus context, and
+# analyst attention.
+#
+# Override path: SAMPLE_MATRIX_NO_SURFACE_FILTER=1 bypasses the entire
+# surface filter (already wired through `_flatten_all` in
+# tools/sample_matrix_run.py), which re-includes A.5 / C.5 alongside the
+# other surface-filtered pairs — useful for an explicit re-validation run
+# of the upstream-escalation tracker.
+ROGUE_AGENT_ADVISORY_ROLES = {'A.5', 'C.5'}
+
+
 def is_low_yield(category: str, role: str) -> bool:
     """Return True if (category, role) is a low-yield pair the sampler should skip.
 
-    "Low yield" = the role's required surface doesn't overlap with what the
-    category exposes. Roles with empty required-surface (A.4, A.5, C.4, C.5,
-    E) apply anywhere and are never low-yield.
+    Two reasons a pair is low-yield:
+
+    1. Rogue-agent advisory: roles A.5 / C.5 produce harmful prose with no
+       MCP/skill trust boundary. Their findings always bulk-close as
+       architectural / out-of-scope at the MCP repo. Excluded for every
+       category — they have no defensible surface anywhere here.
+
+    2. Surface mismatch: the role's required surface doesn't overlap with
+       what the category exposes. Roles with empty required-surface (A.4,
+       C.4, E) apply anywhere and are never low-yield via this branch.
     """
+    if role in ROGUE_AGENT_ADVISORY_ROLES:
+        return True
     cat_surfaces = CATEGORY_SURFACES.get(category, {'signing', 'read'})
     role_required = ROLE_REQUIRED_SURFACES.get(role, set())
     if not role_required:


### PR DESCRIPTION
Closes #57.

## Summary

Adds an explicit `ROGUE_AGENT_ADVISORY_ROLES = {'A.5', 'C.5'}` short-circuit at the top of `is_low_yield()` in `tools/surface_taxonomy.py`. Cells whose role is A.5 or C.5 are now treated as low-yield for every category, so the sampler excludes them from new partitions.

These two roles produce harmful prose with no MCP/skill trust boundary. Their findings consistently bulk-close as architectural / Rogue-Agent-Only at the MCP repo (canonical: vaultpilot-mcp#536; recent batch closures #595/#596/#597/#598/#583/#584/#585/#586 + earlier #540/#541/#543/#544). Defense lives at the chat-client output filter (A.5a / C.5a injection-shaped) or Anthropic model-layer safety (A.5b / C.5b model-shaped) — neither in scope for this MCP. The methodology already routes A.5 / C.5 findings to §7 upstream-escalation on the **filing** side (#52); this change complements that on the **generation** side: stop paying Haiku throughput, Phase-5 Opus context, and analyst attention to dispatch them.

## Acceptance check (per issue body)

- [x] `is_low_yield('any_category', 'A.5')` and `is_low_yield('any_category', 'C.5')` return `True`.
- [x] `SAMPLE_MATRIX_NO_SURFACE_FILTER=1` continues to bypass the exclusion (no extra wiring needed — `_flatten_all` already short-circuits the entire surface filter when the env var is set).
- [ ] After re-init, `partition.json` contains zero cells with `role` ∈ {A.5, C.5}. **Operator step — see "Partition regeneration" below; not done in this PR.**
- [ ] Cell count drops from 9020 to ~7680. **Operator step — same as above.**

## Partition regeneration

`runs/matrix-sampled/partition.json` is intentionally **not** regenerated in this PR. The current partition has batches 1–4 completed; running `init --force` would lose their `completed` status, and the issue's "Suggested workflow" describes a snapshot + carry-forward sequence that's an operator judgment call, not something to bake into a code change.

Recommended sequence after this PR merges (per #57):

1. Snapshot existing artifacts to `runs/matrix-sampled/.archive/2026-05-08-pre-a5c5-drop/` (or whatever date suits) for traceability.
2. `python3 tools/sample_matrix_run.py init --force` against the new taxonomy.
3. Carry forward `completed` status for batches 1–4 into the new `progress.json` — those cells were sampled from the old plan and their findings still stand. Subsequent batch numbering restarts against the new partition's slicing.

## Tests

`tests/suites/100-surface-taxonomy.sh` updated to flip the four assertions that previously checked "category keeps A.5 / C.5" to "category excludes A.5 / C.5", and a new Test 2b block exercises the rogue-agent-advisory exclusion across `tax_regulatory`, `send_native`, `edge_unsupported`, and an unknown category. Test 5 (edge_unsupported) re-anchors on `A.4` since A.5 is no longer the surface-agnostic exemplar there. Test 7 still validates that the env override re-includes everything.

The mock test suite (`tests/run-all.sh`) wasn't executable from inside the agent's bash sandbox, so the diff was reasoned through statically rather than executed locally — flagging this for reviewer awareness.

## Test plan

- [ ] `./tests/run-all.sh` passes locally — particularly suite `100-surface-taxonomy.sh`.
- [ ] `python3 -c "from tools.surface_taxonomy import is_low_yield; print(is_low_yield('send_native', 'A.5'), is_low_yield('tax_regulatory', 'C.5'))"` prints `True True`.
- [ ] `SAMPLE_MATRIX_NO_SURFACE_FILTER=1` re-includes A.5 / C.5: `_flatten_all(apply_surface_filter=False)` minus `_flatten_all(apply_surface_filter=True)` yields the expected delta (≈1340 + the existing surface-filtered pairs).

— Advisory Scope Boundary (agent-916a)
