### PR TITLE
cost-anchor: drop DEFAULT_TOKENS_PER_CELL from 130k to 50k

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Before EVERY batch, surface the cost preflight block AND wait for explicit user 
 ### Per-subagent token anchors
 
 - Honest mode (Haiku per-cell): ~35k total.
-- Adversarial mode (Haiku per-cell, full preflight + multi-tool): **~130k total** per subagent (post-batch-1 measured average).
+- Adversarial mode (Haiku per-cell, simulated MCP via Read + Write only): **~50k total** per subagent (batch-5 measured average ~45k, rounded up for headroom). Earlier batch-1 anchor of ~130k reflected actual MCP tool calls + multi-step preflight; post-28537d2 cell-prompt simplification dropped the per-cell footprint ~2.9x.
 - Phase 5 analysis subagent (Opus): **~82k total** (batch-1 measured).
 
 Quota-relevant total ≈ analysis subagent only — Haiku doesn't deplete weekly buckets on Max-x20.
@@ -246,7 +246,7 @@ python3 tools/sample_matrix_run.py mark-completed --batch NN     # 2. auto-aggre
 # 4. orchestrator files via tools/file_batch_issues.py → batch-NN/issues.md
 ```
 
-Batch sizing: at the post-batch-1 anchor (130k/cell), `init` slices ~9 cells/batch ≈ 1000 batches for the 9020-cell matrix. Existing batch-1 partition kept its old 25k anchor (50 cells) — that's fine; partition is captured at init.
+Batch sizing: at the post-batch-5 anchor (50k/cell), `init` slices ~25 cells/batch ≈ 360 batches for the 9020-cell matrix. Existing partitions captured at init time keep their original anchor and batch_size — the change applies only on re-init.
 
 ### Per-batch quality gate (stop-the-line)
 

--- a/tools/sample_matrix_run.py
+++ b/tools/sample_matrix_run.py
@@ -18,7 +18,7 @@ Sampling strategy:
   - Shuffle once with a fixed seed (default 42) — deterministic, reproducible.
   - Slice into batches of N cells, where
         N = floor(SESSION_ALL_MODELS × BATCH_SESSION_FRACTION / TOKENS_PER_CELL)
-    Defaults (post batch-1 recalibration): 5M × 0.25 / 130k ≈ 9 cells/batch
+    Defaults (post batch-5 recalibration): 5M × 0.25 / 50k ≈ 25 cells/batch
     for new partitions. Existing partition.json captured at init time keeps
     its old anchor and batch_size — change applies only on re-init. Note:
     Haiku is quota-free per the user's Max-x20 dashboard observation, so the
@@ -100,11 +100,17 @@ from surface_taxonomy import is_low_yield  # noqa: E402
 # if these don't match what you see on https://console.anthropic.com .
 DEFAULT_ALL_MODELS_WEEKLY = 50_000_000  # placeholder; verify against dashboard
 DEFAULT_SESSION_ALL_MODELS = 5_000_000  # placeholder 5-hour rolling window cap
-DEFAULT_TOKENS_PER_CELL = 130_000       # measured Haiku adversarial-cell average across batch-1's 50 subagents (range ~125-155k); quota-free per dashboard
-                                        # Earlier 25k anchor was from a smaller-corpus
-                                        # honest-mode pre-14-role measurement; 14-role
-                                        # adversarial cells with full preflight + MCP
-                                        # tool calls measure ~5x higher.
+DEFAULT_TOKENS_PER_CELL = 50_000        # measured Haiku adversarial-cell average across batch-5's 56 subagents (~45k, range 44.4k-46.8k); quota-free per dashboard
+                                        # Anchor history:
+                                        #   25k — pre-14-role honest-mode measurement.
+                                        #   130k — batch-1's 50 subagents (range ~125-155k), when
+                                        #     adversarial cells invoked MCP tools and ran multi-step
+                                        #     preflight on-chain.
+                                        #   50k — current. Post-28537d2 cell-prompt simplification, the
+                                        #     dispatch subagent's tool-call shape collapsed to 2 calls
+                                        #     (Read prompt + Write transcript), with simulated MCP
+                                        #     interaction in transcript prose; per-cell footprint
+                                        #     dropped ~2.9x. Rounded up from observed 45k for headroom.
 DEFAULT_ANALYSIS_TOKENS = 82_000        # measured Phase 5 Opus analysis run on batch-1 (was 100k anchor; now using observed)
 DEFAULT_BATCH_SESSION_FRACTION = 0.25   # batch fills this much of one 5-hour session
                                         # (Phase D resample: tightened from 0.5
@@ -2005,7 +2011,7 @@ def main() -> None:
                         help='5-hour all-models cap in tokens (default: 5M; tune to plan)')
     p_init.add_argument('--per-cell', dest='per_cell',
                         type=int, default=DEFAULT_TOKENS_PER_CELL,
-                        help='Tokens per cell estimate (default: 130k — batch-1 measured)')
+                        help='Tokens per cell estimate (default: 50k — batch-5 measured)')
     p_init.add_argument('--analysis-tokens', dest='analysis_tokens',
                         type=int, default=DEFAULT_ANALYSIS_TOKENS,
                         help='Phase 5 analysis subagent token estimate '


### PR DESCRIPTION
Closes #72

## Summary

Drops `DEFAULT_TOKENS_PER_CELL` in `tools/sample_matrix_run.py` from 130k to 50k. The 130k anchor was measured against batch-1's 50 subagents (range ~125–155k), when adversarial cells actually invoked MCP tools and ran multi-step preflight. Post-`28537d2` and adjacent cell-prompt simplifications, the dispatch subagent's tool-call shape collapsed to **2 calls** (Read prompt + Write transcript) with the simulated MCP interaction in transcript prose. Batch-5 average across 56 cells: ~45k/cell (range 44.4k–46.8k), so the prior anchor overstates by ~2.9×.

## Why this matters

`init` derives batch size as `floor(SESSION_ALL_MODELS × BATCH_SESSION_FRACTION / TOKENS_PER_CELL)`. At 130k, that's `5M × 0.25 / 130k ≈ 9 cells/batch` ≈ 1000 batches for the 9020-cell matrix. At 50k, it's `5M × 0.25 / 50k ≈ 25 cells/batch` ≈ 360 batches — closer to one fully usable session of dispatch headroom per batch. Phase 2.5 cost preflight also stops over-reporting dispatch tokens by 2.9×.

## Scope (matches the issue's note)

- Existing `partition.json` captures the anchor at init time per the methodology, so the current run keeps its original 130k anchor / 9-cell batches. Per-batch numbers in `progress.json` won't change retroactively.
- The new 50k default applies on the next `init` cycle (or via `--per-cell` override).

## Files

- `tools/sample_matrix_run.py` — constant + adjacent comment block (anchor history preserved: 25k → 130k → 50k), docstring at line ~21, `--per-cell` help text.
- `CLAUDE.md` — Phase 2.5 "Per-subagent token anchors" line + the "Batch sizing" paragraph beneath the per-batch loop.

No test changes — the suite uses synth partitions with `tokens_per_cell: 25000` and doesn't reference the production default.

— Alonzo (agent-92ff)
